### PR TITLE
[#11] Add error handling for start failures on a child

### DIFF
--- a/c/core.go
+++ b/c/core.go
@@ -185,7 +185,7 @@ func (cs ChildSpec) Start(
 	// Wait until child thread notifies it has started or failed with an error
 	err := <-startCh
 	if err != nil {
-		return Child{runtimeName: runtimeName, spec: cs}, err
+		return Child{}, err
 	}
 
 	return Child{

--- a/c/core.go
+++ b/c/core.go
@@ -69,7 +69,7 @@ func New(name string, childMain func(context.Context) error, opts ...Opt) ChildS
 // initialized, otherwise the parent supervisor will block and eventually fail
 // with a timeout.
 //
-// #### Report an start error on `NotifyStartFn`
+// #### Report a start error on `NotifyStartFn`
 //
 // If for some reason, a child is not able to start correctly, the child should
 // call the `NotifyStartFn` function with the start `error`.

--- a/c/core.go
+++ b/c/core.go
@@ -182,7 +182,7 @@ func (cs ChildSpec) Start(
 		)
 	}()
 
-	// Wait until child thread notifies it has started
+	// Wait until child thread notifies it has started or failed with an error
 	err := <-startCh
 	if err != nil {
 		return Child{runtimeName: runtimeName, spec: cs}, err

--- a/c/types.go
+++ b/c/types.go
@@ -54,6 +54,16 @@ func Timeout(d time.Duration) Shutdown {
 // Opt is used to configure a child's specification
 type Opt func(*ChildSpec)
 
+// NotifyStartFn is a function given to supervisor children to notify the
+// supervisor that the child has started.
+//
+// ### Notify child's start failure
+//
+// In case the child cannot get started it should call this function with an
+// error value different than nil.
+//
+type NotifyStartFn = func(error)
+
 // ChildSpec represents a Child specification; it serves as a template for the
 // construction of a worker goroutine. The ChildSpec record is used in conjunction
 // with the supervisor's ChildSpec.
@@ -61,7 +71,7 @@ type ChildSpec struct {
 	name     string
 	shutdown Shutdown
 	restart  Restart
-	start    func(context.Context, func() /* notifyStart */) error
+	start    func(context.Context, NotifyStartFn) error
 }
 
 // Child is the runtime representation of an Spec

--- a/s/core.go
+++ b/s/core.go
@@ -223,7 +223,8 @@ func (spec SupervisorSpec) start(parentCtx context.Context, parentName string) (
 			startTime := time.Now()
 			c, err := cs.Start(sup.runtimeName, sup.handleChildResult())
 			if err != nil {
-				eventNotifier.ProcessStopped(c.RuntimeName(), startTime, err)
+				cRuntimeName := strings.Join([]string{sup.runtimeName, cs.Name()}, "/")
+				eventNotifier.ProcessStopped(cRuntimeName, startTime, err)
 				stopChildrenFn(true /* starting? */)
 				// Is important we stop the children before we finish the supervisor
 				startCh <- err

--- a/s/core.go
+++ b/s/core.go
@@ -110,7 +110,7 @@ func (spec SupervisorSpec) getEventNotifier() EventNotifier {
 func subtreeMain(
 	parentName string,
 	spec SupervisorSpec,
-) func(context.Context, func(error)) error {
+) func(context.Context, c.NotifyStartFn) error {
 	// we use the start version that receives the notifyChildStart callback, this
 	// is essential, as we need this callback to signal the sub-tree children have
 	// started before signaling we have started
@@ -195,10 +195,10 @@ func (spec SupervisorSpec) start(parentCtx context.Context, parentName string) (
 	// stopChildrenFn is used on the shutdown of the supervisor tree, it stops
 	// children in the desired order. The starting argument indicates if the
 	// supervision tree is starting, if that is the case, it is more permisive
-	// around runtime children not matching one to one with it's corresponding
-	// spec, this may happen because we had a start error in the middle of
-	// supervision tree initialization, and we never got to initialize all
-	// children at this supervision level.
+	// around spec children not matching one to one with it's corresponding
+	// runtime children, this may happen because we had a start error in the
+	// middle of supervision tree initialization, and we never got to initialize
+	// all children at this supervision level.
 	stopChildrenFn := func(starting bool) {
 		children := spec.order.SortStop(spec.children)
 		for _, cs := range children {

--- a/s/core_test.go
+++ b/s/core_test.go
@@ -88,6 +88,7 @@ func ExampleNew() {
 	sup, err := rootSpec.Start(context.Background())
 	if err != nil {
 		fmt.Printf("Error starting system: %v\n", err)
+		return
 	}
 
 	// Wait for supervision tree to exit, this will only happen when errors cannot

--- a/s/core_test.go
+++ b/s/core_test.go
@@ -216,10 +216,11 @@ func TestStartFailedChild(t *testing.T) {
 		WaitDoneChild("child1"),
 		WaitDoneChild("child2"),
 		FailStartChild("child3"),
+		WaitDoneChild("child4"),
 	}
 
 	b0 := s.New(b0n, s.WithChildren(cs[0], cs[1]))
-	b1 := s.New(b1n, s.WithChildren(cs[2], cs[3]))
+	b1 := s.New(b1n, s.WithChildren(cs[2], cs[3], cs[4]))
 
 	events, err := ObserveSupervisor(
 		context.TODO(),
@@ -240,9 +241,18 @@ func TestStartFailedChild(t *testing.T) {
 			ProcessStarted("root/branch0/child1"),
 			ProcessStarted("root/branch0"),
 			ProcessStarted("root/branch1/child2"),
-			// we get the failing start
+			//
+			// child3 fails at this point
+			//
 			ProcessFailed("root/branch1/child3"),
-			// immediately stop started children in the reverse order
+			//
+			// A few things will happen:
+			//
+			// * child4 initialization is skipped because of an error on previous
+			// sibling
+			//
+			// * previous children get stopped in reversed order
+			//
 			ProcessStopped("root/branch1/child2"),
 			ProcessFailed("root/branch1"),
 			ProcessStopped("root/branch0/child1"),

--- a/s/core_test.go
+++ b/s/core_test.go
@@ -228,7 +228,7 @@ func TestStartFailedChild(t *testing.T) {
 			s.WithSubtree(b0),
 			s.WithSubtree(b1),
 		},
-		func(EventManager) {},
+		func(em EventManager) {},
 	)
 
 	assert.Error(t, err)

--- a/s/core_test.go
+++ b/s/core_test.go
@@ -216,6 +216,7 @@ func TestStartFailedChild(t *testing.T) {
 		WaitDoneChild("child0"),
 		WaitDoneChild("child1"),
 		WaitDoneChild("child2"),
+		// NOTE: FailStartChild here
 		FailStartChild("child3"),
 		WaitDoneChild("child4"),
 	}
@@ -243,16 +244,18 @@ func TestStartFailedChild(t *testing.T) {
 			ProcessStarted("root/branch0"),
 			ProcessStarted("root/branch1/child2"),
 			//
-			// child3 fails at this point
+			// Note child3 fails at this point
 			//
 			ProcessFailed("root/branch1/child3"),
 			//
-			// A few things will happen:
+			// After a failure a few things will happen:
 			//
-			// * child4 initialization is skipped because of an error on previous
-			// sibling
+			// * The `child4` worker initialization is skipped because of an error on
+			// previous sibling
 			//
-			// * previous children get stopped in reversed order
+			// * Previous sibling children get stopped in reversed order
+			//
+			// * The start function returns an error
 			//
 			ProcessStopped("root/branch1/child2"),
 			ProcessFailed("root/branch1"),

--- a/stest/assertions.go
+++ b/stest/assertions.go
@@ -128,6 +128,19 @@ func WaitDoneChild(name string) c.ChildSpec {
 	return cspec
 }
 
+// FailStartChild creates a `ChildSpec` that runs a goroutine that fails on
+// start
+func FailStartChild(name string) c.ChildSpec {
+	cspec := c.NewWithNotifyStart(
+		name,
+		func(ctx context.Context, notifyStart c.NotifyStartFn) error {
+			err := fmt.Errorf("FailStartChild %s", name)
+			notifyStart(err)
+			return err
+		})
+	return cspec
+}
+
 // ObserveSupervisor is an utility function that receives all the arguments
 // required to build a SupervisorSpec, and a callback that when executed will
 // block until some point in the future (after we performed the side-effects we
@@ -154,7 +167,7 @@ func ObserveSupervisor(
 	// embedded in the ObserveSupervisor call
 	sup, err := spec.Start(ctx)
 	if err != nil {
-		return []s.Event{}, err
+		return evManager.Snapshot(), err
 	}
 
 	evIt := evManager.Iterator()

--- a/stest/assertions.go
+++ b/stest/assertions.go
@@ -166,14 +166,16 @@ func ObserveSupervisor(
 	// We always want to start the supervisor for test purposes, so this is
 	// embedded in the ObserveSupervisor call
 	sup, err := spec.Start(ctx)
-	if err != nil {
-		return evManager.Snapshot(), err
-	}
 
 	evIt := evManager.Iterator()
 
 	// Make sure all the tree started before doing assertions
-	evIt.SkipTill(ProcessStarted(rootName))
+	evIt.SkipTill(ProcessName(rootName))
+
+	if err != nil {
+		callback(evManager)
+		return evManager.Snapshot(), err
+	}
 
 	// callback to do assertions with the event manager
 	callback(evManager)
@@ -184,7 +186,7 @@ func ObserveSupervisor(
 		return []s.Event{}, err
 	}
 	// we wait till all the events have been reported
-	evIt.SkipTill(ProcessStopped(rootName))
+	evIt.SkipTill(ProcessName(rootName))
 
 	// return all the events reported by the supervision system
 	return evManager.Snapshot(), nil

--- a/stest/eventp.go
+++ b/stest/eventp.go
@@ -79,6 +79,12 @@ func (p AndP) String() string {
 	return strings.Join(acc, " && ")
 }
 
+// ProcessName is a predicate to assert an event was triggered by the given
+// runtime process name
+func ProcessName(name string) EventP {
+	return ProcessNameP{name: name}
+}
+
 // ProcessStarted is a predicate to assert an event represents a process that
 // got started
 func ProcessStarted(name string) EventP {


### PR DESCRIPTION
### Context

When a Child worker fails to get started when the supervision tree starts, the start mechanism should fail and stop all previously started children

### Acceptance Criteria

   - [X] There are new mechanisms that allow child workers notify that the start failed
   - [X] There are tests that assert a supervision tree halts start when a child fails to start
   - [X] There are tests that verify a supervision tree stops previously started children
