### PR TITLE
Make sure to use golang from nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -152,4 +152,6 @@ validate_version() {
 }
 
 use_nix -s shell.nix -w .nixpkgs-version.json
+export GO111MODULE=on
+export GOPATH="$(pwd)/.pkgs"
 figlet "go-Capataz"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage.txt
+.pkgs
 .direnv

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,6 @@ let
   pinnedVersion = builtins.fromJSON (builtins.readFile ./.nixpkgs-version.json);
   pinnedPkgs = import (builtins.fetchGit {
     inherit (pinnedVersion) url rev;
-
     ref = "nixos-unstable";
   }) {};
 
@@ -42,7 +41,7 @@ in
       figlet
 
       # current go version
-      # go_1_12
+      go_1_13
 
       # miscellaneous gathering of data
       jq     # json


### PR DESCRIPTION
### Context

As a software developer
I want to manage my go dependency from nix
So that I don't have to worry to install the right version of golang to run this project