### PR TITLE
Handle errors on supervision tree termination

### DIFF
--- a/c/core.go
+++ b/c/core.go
@@ -80,7 +80,15 @@ func NewWithNotifyStart(
 	startFn func(context.Context, NotifyStartFn) error,
 	opts ...Opt,
 ) ChildSpec {
-	spec := ChildSpec{}
+	spec := ChildSpec{
+		// Child workers by default will have 5 seconds to terminate before
+		// reporting a timeout error as specified on the Erlang OTP documentation.
+		// http://erlang.org/doc/design_principles/sup_princ.html#tuning-the-intensity-and-period
+		//
+		// Note there is no brutal kill from the supervisor as Go (for better or
+		// worse), does not offer guaranteed kill signals for goroutines.
+		shutdown: Timeout(5 * time.Second),
+	}
 
 	if name == "" {
 		panic("Child cannot have empty name")

--- a/c/core.go
+++ b/c/core.go
@@ -16,6 +16,7 @@ func WithRestart(r Restart) Opt {
 }
 
 // WithShutdown specifies how the shutdown of the child is going to be handled.
+// Read `Inf` and `Timeout` Shutdown values documentation for details.
 func WithShutdown(s Shutdown) Opt {
 	return func(spec *ChildSpec) {
 		spec.shutdown = s

--- a/c/core.go
+++ b/c/core.go
@@ -241,12 +241,6 @@ func (c Child) Name() string {
 	return c.spec.Name()
 }
 
-// // Wait blocks the execution of the current goroutine until the child finishes
-// // it execution.
-// func (c Child) Wait() error {
-//	return c.wait(c.spec.shutdown)
-// }
-
 // Stop is a synchronous procedure that halts the execution of the child
 func (c Child) Stop() error {
 	c.cancel()

--- a/c/core.go
+++ b/c/core.go
@@ -232,11 +232,11 @@ func (c Child) Name() string {
 	return c.spec.Name()
 }
 
-// Wait blocks the execution of the current goroutine until the child finishes
-// it execution.
-func (c Child) Wait() error {
-	return c.wait(c.spec.shutdown)
-}
+// // Wait blocks the execution of the current goroutine until the child finishes
+// // it execution.
+// func (c Child) Wait() error {
+//	return c.wait(c.spec.shutdown)
+// }
 
 // Stop is a synchronous procedure that halts the execution of the child
 func (c Child) Stop() error {

--- a/c/core.go
+++ b/c/core.go
@@ -124,19 +124,19 @@ func waitTimeout(
 		case infinityT:
 			// We wait forever for the result
 			notification, ok := <-terminateCh
-			// A child may have terminated with an error
 			if !ok {
 				return nil
 			}
+			// A child may have terminated with an error
 			return notification.Unwrap()
 		case timeoutT:
 			// we wait until some duration
 			select {
 			case notification, ok := <-terminateCh:
-				// A child may have terminated with an error
 				if !ok {
 					return nil
 				}
+				// A child may have terminated with an error
 				return notification.Unwrap()
 			case <-time.After(shutdown.duration):
 				return errors.New("Child shutdown timeout")

--- a/c/types.go
+++ b/c/types.go
@@ -81,3 +81,20 @@ type Child struct {
 	cancel      func()
 	wait        func(Shutdown) error
 }
+
+// ChildNotification reports when a child has finished
+type ChildNotification struct {
+	runtimeName string
+	err         error
+}
+
+// RuntimeName returns the runtime name of the child that emitted this exit
+// notification
+func (ce ChildNotification) RuntimeName() string {
+	return ce.runtimeName
+}
+
+// Unwrap returns the error reported by ChildNotification, if any.
+func (ce ChildNotification) Unwrap() error {
+	return ce.err
+}

--- a/c/types.go
+++ b/c/types.go
@@ -44,6 +44,11 @@ var Inf = Shutdown{tag: infinityT}
 
 // Timeout specifies a duration of time the parent supervisor will wait for the
 // child goroutine to stop executing
+//
+// Note, in case of the Timeout being reached, our Supervisor won't do a brutal
+// kill -- Go (for better or worse), does not offer guaranteed kill signals for
+// goroutines. Whenever there is a timeout registered, there is a chance your
+// Child goroutine may be leaking.
 func Timeout(d time.Duration) Shutdown {
 	return Shutdown{
 		tag:      timeoutT,

--- a/s/core_test.go
+++ b/s/core_test.go
@@ -275,6 +275,7 @@ func TestStopFailedChild(t *testing.T) {
 	cs := []c.ChildSpec{
 		WaitDoneChild("child0"),
 		WaitDoneChild("child1"),
+		// NOTE: There is a NeverStopChild here
 		NeverStopChild("child2"),
 		WaitDoneChild("child3"),
 	}

--- a/s/core_test.go
+++ b/s/core_test.go
@@ -292,10 +292,6 @@ func TestStopFailedChild(t *testing.T) {
 		func(em EventManager) {},
 	)
 
-	for _, ev := range events {
-		fmt.Printf("%s %s %v\n", ev.ProcessRuntimeName(), ev.Tag().String(), ev.Err())
-	}
-
 	assert.Error(t, err)
 
 	AssertExactMatch(t, events,

--- a/s/types.go
+++ b/s/types.go
@@ -234,3 +234,11 @@ func (se SupervisorError) Error() string {
 	}
 	return "Supervisor failure"
 }
+
+// startError is the error reported back to a Supervisor when
+// the start of a Child fails
+type startError = error
+
+// terminateError is the error reported back to a Supervisor when
+// the termination of a Child fails
+type terminateError = error

--- a/stest/assertions.go
+++ b/stest/assertions.go
@@ -215,15 +215,14 @@ func ObserveSupervisor(
 
 	// once tests are done, we stop the supervisor
 	err = sup.Stop()
-	if err != nil {
-		// TODO: We should return the events that got accumulated so far instead
-		// here (Snapshot), this work is going to be done in PR for issue #16
-		return []s.Event{}, err
-	}
 
 	// We wait till all the events have been reported (event from root must be the
 	// last event)
 	evIt.SkipTill(ProcessName(rootName))
+
+	if err != nil {
+		return evManager.Snapshot(), err
+	}
 
 	// return all the events reported by the supervision system
 	return evManager.Snapshot(), nil


### PR DESCRIPTION
Closes #16 

### Acceptance Criteria

 * [X] There is a test that asserts that even though a child failed on stop, the stopping mechanism continues
 * [X]  There is a comment that warns API consumers that a worker with a shutdown timeout expired is going to be leaked (golang does not offer brutal kill capabilities)
 * [X] Supervisors have a default shutdown of Infinity
 * [x] Workers have a default shutdown of 5 seconds

### Note

Code coverage got reduced because of a few getter/setters on the `c/types` file, please ignore coverage errors
