### PR TITLE
Split s/core.go into mutliple files

### DIFF
--- a/s/children.go
+++ b/s/children.go
@@ -1,5 +1,7 @@
 package s
 
+// This file contains the start/stop children logic
+
 import (
 	"fmt"
 	"strings"

--- a/s/children.go
+++ b/s/children.go
@@ -1,0 +1,86 @@
+package s
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/capatazlib/go-capataz/c"
+)
+
+// stopChildren is used on the shutdown of the supervisor tree, it stops
+// children in the desired order. The starting argument indicates if the
+// supervision tree is starting, if that is the case, it is more permisive
+// around spec children not matching one to one with it's corresponding runtime
+// children, this may happen because we had a start error in the middle of
+// supervision tree initialization, and we never got to initialize all children
+// at this supervision level.
+func (sup Supervisor) stopChildren(
+	starting bool,
+) map[string]error {
+	spec := sup.spec
+	eventNotifier := spec.eventNotifier
+	children := spec.order.SortStop(spec.children)
+	childErrMap := make(map[string]error)
+
+	for _, cs := range children {
+		c, ok := sup.children[cs.Name()]
+		if !ok && starting {
+			// skip it as we may have not started this child before a previous one
+			// failed
+			continue
+		} else if !ok {
+			// There is no excuse for a runtime child to not have a corresponding
+			// spec, this is a serious implementation error.
+			panic(
+				fmt.Sprintf(
+					"Invariant violetated: Child %s is not on started list",
+					cs.Name(),
+				),
+			)
+		}
+		stopTime := time.Now()
+		err := c.Stop()
+		// If a child fails to stop (either because of a legit failure or a
+		// timeout), we store the error so that we can report all of them later
+		if err != nil {
+			childErrMap[cs.Name()] = err
+		}
+		eventNotifier.ProcessStopped(c.RuntimeName(), stopTime, err)
+	}
+	return childErrMap
+}
+
+// startChildren iterates over all the children (specified with `s.WithChildren`
+// and `s.WithSubtree`) starting a goroutine for each. The children iteration
+// will be sorted as specified with the `s.WithOrder` option. In case any child
+// fails to start, the supervisor start operation will be aborted and all the
+// started children so far will be stopped in the reverse order.
+func (sup Supervisor) startChildren(
+	notifyCh chan c.ChildNotification,
+) error {
+	spec := sup.spec
+	eventNotifier := spec.getEventNotifier()
+
+	// Start children
+	for _, cs := range spec.order.SortStart(spec.children) {
+		startTime := time.Now()
+		c, err := cs.Start(sup.runtimeName, notifyCh)
+		// NOTE: The error handling code bellow gets executed when the children
+		// fails at start time
+		if err != nil {
+			cRuntimeName := strings.Join([]string{sup.runtimeName, cs.Name()}, "/")
+			eventNotifier.ProcessStopped(cRuntimeName, startTime, err)
+			childErrMap := sup.stopChildren(true /* starting? */)
+			// Is important we stop the children before we finish the supervisor
+			return SupervisorError{
+				err:         err,
+				runtimeName: sup.runtimeName,
+				childErrMap: childErrMap,
+			}
+		}
+		eventNotifier.ProcessStarted(c.RuntimeName(), startTime)
+		sup.children[cs.Name()] = c
+	}
+	return nil
+}

--- a/s/core.go
+++ b/s/core.go
@@ -14,45 +14,6 @@ import (
 // compare the process current name to the rootSupervisorName
 var rootSupervisorName = ""
 
-// WithOrder specifies the start/stop order of a supervisor's children
-func WithOrder(o Order) Opt {
-	return func(spec *SupervisorSpec) {
-		spec.order = o
-	}
-}
-
-// WithStrategy specifies how children get restarted when one of them fails
-func WithStrategy(s Strategy) Opt {
-	return func(spec *SupervisorSpec) {
-		spec.strategy = s
-	}
-}
-
-// WithNotifier specifies a callback that gets called whenever the supervision
-// system reports an Event
-func WithNotifier(en EventNotifier) Opt {
-	return func(spec *SupervisorSpec) {
-		spec.eventNotifier = en
-	}
-}
-
-// WithChildren specifies a list of child Spec that will get started when the
-// supervisor starts
-func WithChildren(children ...c.ChildSpec) Opt {
-	return func(spec *SupervisorSpec) {
-		spec.children = append(spec.children, children...)
-	}
-}
-
-// WithSubtree specifies a supervisor sub-tree. Is intended to be used when
-// composing sub-systems in a supervision tree.
-func WithSubtree(subtree SupervisorSpec, copts ...c.Opt) Opt {
-	return func(spec *SupervisorSpec) {
-		cspec := spec.Subtree(subtree, copts...)
-		WithChildren(cspec)(spec)
-	}
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Supervisor (dynamic tree) functionality
 

--- a/s/core.go
+++ b/s/core.go
@@ -54,51 +54,6 @@ func (spec SupervisorSpec) getEventNotifier() EventNotifier {
 	return spec.eventNotifier
 }
 
-// subtreeMain contains the main logic of the Child spec that runs a supervision
-// sub-tree. It returns an error if the child supervisor fails to start.
-func subtreeMain(
-	parentName string,
-	spec SupervisorSpec,
-) func(context.Context, c.NotifyStartFn) error {
-	// we use the start version that receives the notifyChildStart callback, this
-	// is essential, as we need this callback to signal the sub-tree children have
-	// started before signaling we have started
-	return func(parentCtx context.Context, notifyChildStart c.NotifyStartFn) error {
-		// in this function we use the private versions of start and wait
-		// given we don't want to signal the eventNotifier more than once
-		// on sub-trees
-
-		ctx, cancelFn := context.WithCancel(parentCtx)
-		defer cancelFn()
-		sup, err := spec.start(ctx, parentName)
-		notifyChildStart(err)
-		if err != nil {
-			return err
-		}
-		return sup.wait()
-	}
-}
-
-// Subtree allows to register a Supervisor Spec as a sub-tree of a bigger
-// Supervisor Spec.
-func (spec SupervisorSpec) Subtree(
-	subtreeSpec SupervisorSpec,
-	copts0 ...c.Opt,
-) c.ChildSpec {
-	subtreeSpec.eventNotifier = spec.eventNotifier
-
-	// NOTE: Child goroutines that are running a sub-tree supervisor must always
-	// have a timeout of Infinity, as specified in the documentation from OTP
-	// http://erlang.org/doc/design_principles/sup_princ.html#child-specification
-	copts := append(copts0, c.WithShutdown(c.Inf))
-
-	return c.NewWithNotifyStart(
-		subtreeSpec.Name(),
-		subtreeMain(spec.name, subtreeSpec),
-		copts...,
-	)
-}
-
 // start is routine that contains the main logic of a Supervisor. This function:
 //
 // 1) spawns a new goroutine for the supervisor loop

--- a/s/core.go
+++ b/s/core.go
@@ -15,22 +15,6 @@ import (
 var rootSupervisorName = ""
 
 ////////////////////////////////////////////////////////////////////////////////
-// Private API
-
-// emptyEventNotifier is an utility function that works as a default value
-// whenever an EventNotifier is not specified on the Supervisor Spec
-func emptyEventNotifier(_ Event) {}
-
-// getEventNotifier returns the configured EventNotifier or emptyEventNotifier
-// (if none is given via WithEventNotifier)
-func (spec SupervisorSpec) getEventNotifier() EventNotifier {
-	if spec.eventNotifier == nil {
-		return emptyEventNotifier
-	}
-	return spec.eventNotifier
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Public API
 
 // Stop is a synchronous procedure that halts the execution of the whole

--- a/s/core.go
+++ b/s/core.go
@@ -54,6 +54,83 @@ func (spec SupervisorSpec) getEventNotifier() EventNotifier {
 	return spec.eventNotifier
 }
 
+// stopChildren is used on the shutdown of the supervisor tree, it stops
+// children in the desired order. The starting argument indicates if the
+// supervision tree is starting, if that is the case, it is more permisive
+// around spec children not matching one to one with it's corresponding runtime
+// children, this may happen because we had a start error in the middle of
+// supervision tree initialization, and we never got to initialize all children
+// at this supervision level.
+func (sup Supervisor) stopChildren(
+	starting bool,
+) map[string]error {
+	spec := sup.spec
+	eventNotifier := spec.eventNotifier
+	children := spec.order.SortStop(spec.children)
+	childErrMap := make(map[string]error)
+
+	for _, cs := range children {
+		c, ok := sup.children[cs.Name()]
+		if !ok && starting {
+			// skip it as we may have not started this child before a previous one
+			// failed
+			continue
+		} else if !ok {
+			// There is no excuse for a runtime child to not have a corresponding
+			// spec, this is a serious implementation error.
+			panic(
+				fmt.Sprintf(
+					"Invariant violetated: Child %s is not on started list",
+					cs.Name(),
+				),
+			)
+		}
+		stopTime := time.Now()
+		err := c.Stop()
+		// If a child fails to stop (either because of a legit failure or a
+		// timeout), we store the error so that we can report all of them later
+		if err != nil {
+			childErrMap[cs.Name()] = err
+		}
+		eventNotifier.ProcessStopped(c.RuntimeName(), stopTime, err)
+	}
+	return childErrMap
+}
+
+// startChildren iterates over all the children (specified with `s.WithChildren`
+// and `s.WithSubtree`) starting a goroutine for each. The children iteration
+// will be sorted as specified with the `s.WithOrder` option. In case any child
+// fails to start, the supervisor start operation will be aborted and all the
+// started children so far will be stopped in the reverse order.
+func (sup Supervisor) startChildren(
+	notifyCh chan c.ChildNotification,
+) error {
+	spec := sup.spec
+	eventNotifier := spec.getEventNotifier()
+
+	// Start children
+	for _, cs := range spec.order.SortStart(spec.children) {
+		startTime := time.Now()
+		c, err := cs.Start(sup.runtimeName, notifyCh)
+		// NOTE: The error handling code bellow gets executed when the children
+		// fails at start time
+		if err != nil {
+			cRuntimeName := strings.Join([]string{sup.runtimeName, cs.Name()}, "/")
+			eventNotifier.ProcessStopped(cRuntimeName, startTime, err)
+			childErrMap := sup.stopChildren(true /* starting? */)
+			// Is important we stop the children before we finish the supervisor
+			return SupervisorError{
+				err:         err,
+				runtimeName: sup.runtimeName,
+				childErrMap: childErrMap,
+			}
+		}
+		eventNotifier.ProcessStarted(c.RuntimeName(), startTime)
+		sup.children[cs.Name()] = c
+	}
+	return nil
+}
+
 // start is routine that contains the main logic of a Supervisor. This function:
 //
 // 1) spawns a new goroutine for the supervisor loop
@@ -81,7 +158,7 @@ func (spec SupervisorSpec) start(parentCtx context.Context, parentName string) (
 	// terminateCh is used when waiting for cancelFn to complete
 	terminateCh := make(chan terminateError)
 
-	eventNotifier := spec.getEventNotifier()
+	// eventNotifier := spec.getEventNotifier()
 
 	var runtimeName string
 	if parentName == rootSupervisorName {
@@ -106,67 +183,14 @@ func (spec SupervisorSpec) start(parentCtx context.Context, parentName string) (
 		},
 	}
 
-	// stopChildrenFn is used on the shutdown of the supervisor tree, it stops
-	// children in the desired order. The starting argument indicates if the
-	// supervision tree is starting, if that is the case, it is more permisive
-	// around spec children not matching one to one with it's corresponding
-	// runtime children, this may happen because we had a start error in the
-	// middle of supervision tree initialization, and we never got to initialize
-	// all children at this supervision level.
-	stopChildrenFn := func(starting bool) map[string]error {
-		children := spec.order.SortStop(spec.children)
-		childErrMap := make(map[string]error)
-		for _, cs := range children {
-			c, ok := sup.children[cs.Name()]
-			if !ok && starting {
-				// skip it as we may have not started this child before a previous one
-				// failed
-				continue
-			} else if !ok {
-				// There is no excuse for a runtime child to not have a corresponding
-				// spec, this is a serious implementation error.
-				panic(
-					fmt.Sprintf(
-						"Invariant violetated: Child %s is not on started list",
-						cs.Name(),
-					),
-				)
-			}
-			stopTime := time.Now()
-			err := c.Stop()
-			// If a child fails to stop (either because of a legit failure or a
-			// timeout), we store the error so that we can report all of them later
-			if err != nil {
-				childErrMap[cs.Name()] = err
-			}
-			eventNotifier.ProcessStopped(c.RuntimeName(), stopTime, err)
-		}
-		return childErrMap
-	}
-
 	go func() {
 		defer close(terminateCh)
 
 		// Start children
-		for _, cs := range spec.order.SortStart(spec.children) {
-			startTime := time.Now()
-			c, err := cs.Start(sup.runtimeName, notifyCh)
-			// NOTE: The error handling code bellow gets executed when the children
-			// fails at start time
-			if err != nil {
-				cRuntimeName := strings.Join([]string{sup.runtimeName, cs.Name()}, "/")
-				eventNotifier.ProcessStopped(cRuntimeName, startTime, err)
-				childErrMap := stopChildrenFn(true /* starting? */)
-				// Is important we stop the children before we finish the supervisor
-				startCh <- SupervisorError{
-					err:         err,
-					runtimeName: runtimeName,
-					childErrMap: childErrMap,
-				}
-				return
-			}
-			eventNotifier.ProcessStarted(c.RuntimeName(), startTime)
-			sup.children[cs.Name()] = c
+		err := sup.startChildren(notifyCh)
+		if err != nil {
+			startCh <- err
+			return
 		}
 
 		// Once children have been spawned we notify the supervisor thread has
@@ -179,7 +203,7 @@ func (spec SupervisorSpec) start(parentCtx context.Context, parentName string) (
 			select {
 			// parent context is done
 			case <-ctx.Done():
-				childErrMap := stopChildrenFn(false /* starting? */)
+				childErrMap := sup.stopChildren(false /* starting? */)
 				// If any of the children fails to stop, we should report that as an
 				// error
 				if len(childErrMap) > 0 {

--- a/s/core.go
+++ b/s/core.go
@@ -3,7 +3,6 @@ package s
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -54,83 +53,6 @@ func (spec SupervisorSpec) getEventNotifier() EventNotifier {
 	return spec.eventNotifier
 }
 
-// stopChildren is used on the shutdown of the supervisor tree, it stops
-// children in the desired order. The starting argument indicates if the
-// supervision tree is starting, if that is the case, it is more permisive
-// around spec children not matching one to one with it's corresponding runtime
-// children, this may happen because we had a start error in the middle of
-// supervision tree initialization, and we never got to initialize all children
-// at this supervision level.
-func (sup Supervisor) stopChildren(
-	starting bool,
-) map[string]error {
-	spec := sup.spec
-	eventNotifier := spec.eventNotifier
-	children := spec.order.SortStop(spec.children)
-	childErrMap := make(map[string]error)
-
-	for _, cs := range children {
-		c, ok := sup.children[cs.Name()]
-		if !ok && starting {
-			// skip it as we may have not started this child before a previous one
-			// failed
-			continue
-		} else if !ok {
-			// There is no excuse for a runtime child to not have a corresponding
-			// spec, this is a serious implementation error.
-			panic(
-				fmt.Sprintf(
-					"Invariant violetated: Child %s is not on started list",
-					cs.Name(),
-				),
-			)
-		}
-		stopTime := time.Now()
-		err := c.Stop()
-		// If a child fails to stop (either because of a legit failure or a
-		// timeout), we store the error so that we can report all of them later
-		if err != nil {
-			childErrMap[cs.Name()] = err
-		}
-		eventNotifier.ProcessStopped(c.RuntimeName(), stopTime, err)
-	}
-	return childErrMap
-}
-
-// startChildren iterates over all the children (specified with `s.WithChildren`
-// and `s.WithSubtree`) starting a goroutine for each. The children iteration
-// will be sorted as specified with the `s.WithOrder` option. In case any child
-// fails to start, the supervisor start operation will be aborted and all the
-// started children so far will be stopped in the reverse order.
-func (sup Supervisor) startChildren(
-	notifyCh chan c.ChildNotification,
-) error {
-	spec := sup.spec
-	eventNotifier := spec.getEventNotifier()
-
-	// Start children
-	for _, cs := range spec.order.SortStart(spec.children) {
-		startTime := time.Now()
-		c, err := cs.Start(sup.runtimeName, notifyCh)
-		// NOTE: The error handling code bellow gets executed when the children
-		// fails at start time
-		if err != nil {
-			cRuntimeName := strings.Join([]string{sup.runtimeName, cs.Name()}, "/")
-			eventNotifier.ProcessStopped(cRuntimeName, startTime, err)
-			childErrMap := sup.stopChildren(true /* starting? */)
-			// Is important we stop the children before we finish the supervisor
-			return SupervisorError{
-				err:         err,
-				runtimeName: sup.runtimeName,
-				childErrMap: childErrMap,
-			}
-		}
-		eventNotifier.ProcessStarted(c.RuntimeName(), startTime)
-		sup.children[cs.Name()] = c
-	}
-	return nil
-}
-
 // start is routine that contains the main logic of a Supervisor. This function:
 //
 // 1) spawns a new goroutine for the supervisor loop
@@ -157,8 +79,6 @@ func (spec SupervisorSpec) start(parentCtx context.Context, parentName string) (
 
 	// terminateCh is used when waiting for cancelFn to complete
 	terminateCh := make(chan terminateError)
-
-	// eventNotifier := spec.getEventNotifier()
 
 	var runtimeName string
 	if parentName == rootSupervisorName {

--- a/s/core.go
+++ b/s/core.go
@@ -10,10 +10,6 @@ import (
 	"github.com/capatazlib/go-capataz/c"
 )
 
-// rootSupervisorName is the name the root supervisor has, this is used to
-// compare the process current name to the rootSupervisorName
-var rootSupervisorName = ""
-
 ////////////////////////////////////////////////////////////////////////////////
 // Public API
 

--- a/s/options.go
+++ b/s/options.go
@@ -1,5 +1,7 @@
 package s
 
+// This file all the constructor options for a SupervisorSpec
+
 import "github.com/capatazlib/go-capataz/c"
 
 // WithOrder specifies the start/stop order of a supervisor's children

--- a/s/options.go
+++ b/s/options.go
@@ -1,0 +1,42 @@
+package s
+
+import "github.com/capatazlib/go-capataz/c"
+
+// WithOrder specifies the start/stop order of a supervisor's children
+func WithOrder(o Order) Opt {
+	return func(spec *SupervisorSpec) {
+		spec.order = o
+	}
+}
+
+// WithStrategy specifies how children get restarted when one of them fails
+func WithStrategy(s Strategy) Opt {
+	return func(spec *SupervisorSpec) {
+		spec.strategy = s
+	}
+}
+
+// WithNotifier specifies a callback that gets called whenever the supervision
+// system reports an Event
+func WithNotifier(en EventNotifier) Opt {
+	return func(spec *SupervisorSpec) {
+		spec.eventNotifier = en
+	}
+}
+
+// WithChildren specifies a list of child Spec that will get started when the
+// supervisor starts
+func WithChildren(children ...c.ChildSpec) Opt {
+	return func(spec *SupervisorSpec) {
+		spec.children = append(spec.children, children...)
+	}
+}
+
+// WithSubtree specifies a supervisor sub-tree. Is intended to be used when
+// composing sub-systems in a supervision tree.
+func WithSubtree(subtree SupervisorSpec, copts ...c.Opt) Opt {
+	return func(spec *SupervisorSpec) {
+		cspec := spec.subtree(subtree, copts...)
+		WithChildren(cspec)(spec)
+	}
+}

--- a/s/start.go
+++ b/s/start.go
@@ -1,0 +1,132 @@
+package s
+
+// This file contains the implementation of the supervision start
+//
+// * Creation of Supervisor from SupervisorSpec
+// * Children bootstrap
+// * Monitor Loop
+//
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/capatazlib/go-capataz/c"
+)
+
+// monitorLoop does the initialization of supervisor's children and then runs an
+// infinite loop that monitors each child error.
+func (sup Supervisor) monitorLoop(
+	ctx context.Context,
+	startCh chan startError,
+	terminateCh chan terminateError,
+	notifyCh chan c.ChildNotification,
+) {
+	defer close(terminateCh)
+
+	// Start children
+	err := sup.startChildren(notifyCh)
+	if err != nil {
+		startCh <- err
+		return
+	}
+
+	// Once children have been spawned we notify the supervisor thread has
+	// started
+	close(startCh)
+
+	// Supervisor Loop
+	for {
+		select {
+		// parent context is done
+		case <-ctx.Done():
+			childErrMap := sup.stopChildren(false /* starting? */)
+			// If any of the children fails to stop, we should report that as an
+			// error
+			if len(childErrMap) > 0 {
+				terminateCh <- SupervisorError{
+					err:         errors.New("Supervisor stop error"),
+					runtimeName: sup.runtimeName,
+					childErrMap: childErrMap,
+				}
+			}
+			return
+		case /* childNotification = */ <-notifyCh:
+			// TODO: Deal with errors on children
+			// case msg := <-ctrlCh:
+			// TODO: Deal with public facing API calls
+		}
+	}
+}
+
+// start is routine that contains the main logic of a Supervisor. This function:
+//
+// 1) spawns a new goroutine for the supervisor loop
+//
+// 2) spawns each child goroutine in the correct order
+//
+// 3) stops all the spawned children in the correct order once it gets a stop
+// signal
+//
+// 4) it monitors and reacts to errors reported by the supervised children
+//
+func (spec SupervisorSpec) start(parentCtx context.Context, parentName string) (Supervisor, error) {
+	// cancelFn is used when Stop is requested
+	ctx, cancelFn := context.WithCancel(parentCtx)
+
+	// notifyCh is used to keep track of errors from children
+	notifyCh := make(chan c.ChildNotification)
+
+	// ctrlCh is used to keep track of request from client APIs (e.g. spawn child)
+	// ctrlCh := make(chan ControlMsg)
+
+	// startCh is used to track when the supervisor loop thread has started
+	startCh := make(chan startError)
+
+	// terminateCh is used when waiting for cancelFn to complete
+	terminateCh := make(chan terminateError)
+
+	// Calculate the runtime name of this supervisor
+	var runtimeName string
+	if parentName == rootSupervisorName {
+		// We are the root supervisor, no need to add prefix
+		runtimeName = spec.Name()
+	} else {
+		runtimeName = strings.Join([]string{parentName, spec.Name()}, "/")
+	}
+
+	sup := Supervisor{
+		runtimeName: runtimeName,
+		spec:        spec,
+		children:    make(map[string]c.Child, len(spec.children)),
+		cancel:      cancelFn,
+		wait: func() error {
+			// Let's us wait for the Supervisor goroutine to terminate, if there are
+			// errors in the termination (e.g. Timeout of child, error treshold
+			// reached, etc.), the terminateCh is going to return an error, otherwise
+			// it will nil
+			err := <-terminateCh
+			return err
+		},
+	}
+
+	// spawn goroutine with supervisor monitorLoop
+	go sup.monitorLoop(ctx, startCh, terminateCh, notifyCh)
+
+	// TODO: Figure out stop before start finish
+	// TODO: Figure out start with timeout
+
+	// We check if there was an start error reported from the monitorLoop, if this
+	// is the case, we wait for the termination of started children and return the
+	// reported error
+	err := <-startCh
+	if err != nil {
+		// Let's wait for the supervisor to stop all children before returning the
+		// final error
+		_ /* err */ = sup.wait()
+		return Supervisor{}, err
+	}
+
+	return sup, nil
+}

--- a/s/subtree.go
+++ b/s/subtree.go
@@ -1,0 +1,52 @@
+package s
+
+import (
+	"context"
+
+	"github.com/capatazlib/go-capataz/c"
+)
+
+// subtreeMain contains the main logic of the Child spec that runs a supervision
+// sub-tree. It returns an error if the child supervisor fails to start.
+func subtreeMain(
+	parentName string,
+	spec SupervisorSpec,
+) func(context.Context, c.NotifyStartFn) error {
+	// we use the start version that receives the notifyChildStart callback, this
+	// is essential, as we need this callback to signal the sub-tree children have
+	// started before signaling we have started
+	return func(parentCtx context.Context, notifyChildStart c.NotifyStartFn) error {
+		// in this function we use the private versions of start and wait
+		// given we don't want to signal the eventNotifier more than once
+		// on sub-trees
+
+		ctx, cancelFn := context.WithCancel(parentCtx)
+		defer cancelFn()
+		sup, err := spec.start(ctx, parentName)
+		notifyChildStart(err)
+		if err != nil {
+			return err
+		}
+		return sup.wait()
+	}
+}
+
+// subtree allows to register a Supervisor Spec as a sub-tree of a bigger
+// Supervisor Spec.
+func (spec SupervisorSpec) subtree(
+	subtreeSpec SupervisorSpec,
+	copts0 ...c.Opt,
+) c.ChildSpec {
+	subtreeSpec.eventNotifier = spec.eventNotifier
+
+	// NOTE: Child goroutines that are running a sub-tree supervisor must always
+	// have a timeout of Infinity, as specified in the documentation from OTP
+	// http://erlang.org/doc/design_principles/sup_princ.html#child-specification
+	copts := append(copts0, c.WithShutdown(c.Inf))
+
+	return c.NewWithNotifyStart(
+		subtreeSpec.Name(),
+		subtreeMain(spec.name, subtreeSpec),
+		copts...,
+	)
+}

--- a/s/subtree.go
+++ b/s/subtree.go
@@ -34,7 +34,8 @@ func subtreeMain(
 }
 
 // subtree allows to register a Supervisor Spec as a sub-tree of a bigger
-// Supervisor Spec.
+// Supervisor Spec. The sub-tree is executed in a `c.Child` goroutine, ergo, the
+// returned `c.ChildSpec` is going to contain the supervisor internally.
 func (spec SupervisorSpec) subtree(
 	subtreeSpec SupervisorSpec,
 	copts0 ...c.Opt,

--- a/s/subtree.go
+++ b/s/subtree.go
@@ -1,5 +1,7 @@
 package s
 
+// This file contains logic on supervision sub-trees
+
 import (
 	"context"
 

--- a/s/types.go
+++ b/s/types.go
@@ -255,3 +255,7 @@ type startError = error
 // terminateError is the error reported back to a Supervisor when
 // the termination of a Child fails
 type terminateError = error
+
+// rootSupervisorName is the name the root supervisor has, this is used to
+// compare the process current name to the rootSupervisorName
+var rootSupervisorName = ""

--- a/s/types.go
+++ b/s/types.go
@@ -168,6 +168,19 @@ func (en EventNotifier) ProcessStarted(name string, startTime time.Time) {
 	})
 }
 
+// emptyEventNotifier is an utility function that works as a default value
+// whenever an EventNotifier is not specified on the Supervisor Spec
+func emptyEventNotifier(_ Event) {}
+
+// getEventNotifier returns the configured EventNotifier or emptyEventNotifier
+// (if none is given via WithEventNotifier)
+func (spec SupervisorSpec) getEventNotifier() EventNotifier {
+	if spec.eventNotifier == nil {
+		return emptyEventNotifier
+	}
+	return spec.eventNotifier
+}
+
 // Opt is used to configure a supervisor's specification
 type Opt func(*SupervisorSpec)
 


### PR DESCRIPTION
### Context

As a go-capataz maintainer
I would like for files to be organized in a way were not all the code logic is in one single file
So that I can find implementation logic faster and reduce blast radius

### Acceptance Criteria

* [x] Module split makes sense
* [x] Behavior is not modified by changes

### Developer notes

* Author recommends reviewing on a by commit basis
* The `s/children.go` is filled with functions that were inline before