### PR TITLE
#24 - Subtrees spawn a single goroutine

### DIFF
--- a/s/start.go
+++ b/s/start.go
@@ -60,6 +60,19 @@ func (sup Supervisor) monitorLoop(
 	}
 }
 
+// buildRuntimeName creates the runtimeName of a Supervisor from the parent name
+// and the spec name
+func buildRuntimeName(spec SupervisorSpec, parentName string) string {
+	var runtimeName string
+	if parentName == rootSupervisorName {
+		// We are the root supervisor, no need to add prefix
+		runtimeName = spec.Name()
+	} else {
+		runtimeName = strings.Join([]string{parentName, spec.Name()}, "/")
+	}
+	return runtimeName
+}
+
 // start is routine that contains the main logic of a Supervisor. This function:
 //
 // 1) spawns a new goroutine for the supervisor loop
@@ -87,14 +100,7 @@ func (spec SupervisorSpec) start(parentCtx context.Context, parentName string) (
 	// terminateCh is used when waiting for cancelFn to complete
 	terminateCh := make(chan terminateError)
 
-	// Calculate the runtime name of this supervisor
-	var runtimeName string
-	if parentName == rootSupervisorName {
-		// We are the root supervisor, no need to add prefix
-		runtimeName = spec.Name()
-	} else {
-		runtimeName = strings.Join([]string{parentName, spec.Name()}, "/")
-	}
+	runtimeName := buildRuntimeName(spec, parentName)
 
 	sup := Supervisor{
 		runtimeName: runtimeName,

--- a/s/start.go
+++ b/s/start.go
@@ -15,6 +15,8 @@ import (
 	"github.com/capatazlib/go-capataz/c"
 )
 
+type NotifyTerminationFn = func(terminateError)
+
 // runMonitorLoop does the initialization of supervisor's children and then runs
 // an infinite loop that monitors each child error.
 //
@@ -34,7 +36,7 @@ func runMonitorLoop(
 	runtimeName string,
 	notifyCh chan c.ChildNotification,
 	onStart c.NotifyStartFn,
-	onTerminate func(terminateError),
+	onTerminate NotifyTerminationFn,
 ) error {
 	// Start children
 	children, err := startChildren(spec, runtimeName, notifyCh)
@@ -48,9 +50,8 @@ func runMonitorLoop(
 		return err
 	}
 
-	// Once children have been spawned we notify the supervisor main loop has
-	// started, we ignore the return given onStart usually returns the given
-	// parameter
+	// Once children have been spawned, we notify to the caller thread that the
+	// main loop has started without errors.
 	onStart(nil)
 
 	// Supervisor Loop

--- a/s/start.go
+++ b/s/start.go
@@ -15,7 +15,9 @@ import (
 	"github.com/capatazlib/go-capataz/c"
 )
 
-type NotifyTerminationFn = func(terminateError)
+// notifyTerminationFn is a callback that gets called when a supervisor is
+// terminating (with or without an error).
+type notifyTerminationFn = func(terminateError)
 
 // runMonitorLoop does the initialization of supervisor's children and then runs
 // an infinite loop that monitors each child error.
@@ -36,7 +38,7 @@ func runMonitorLoop(
 	runtimeName string,
 	notifyCh chan c.ChildNotification,
 	onStart c.NotifyStartFn,
-	onTerminate NotifyTerminationFn,
+	onTerminate notifyTerminationFn,
 ) error {
 	// Start children
 	children, err := startChildren(spec, runtimeName, notifyCh)

--- a/s/subtree.go
+++ b/s/subtree.go
@@ -18,18 +18,11 @@ func subtreeMain(
 	// is essential, as we need this callback to signal the sub-tree children have
 	// started before signaling we have started
 	return func(parentCtx context.Context, notifyChildStart c.NotifyStartFn) error {
-		// in this function we use the private versions of start and wait
-		// given we don't want to signal the eventNotifier more than once
-		// on sub-trees
-
+		// in this function we use the private versions of run given we don't want
+		// to spawn yet another goroutine
 		ctx, cancelFn := context.WithCancel(parentCtx)
 		defer cancelFn()
-		sup, err := spec.start(ctx, parentName)
-		notifyChildStart(err)
-		if err != nil {
-			return err
-		}
-		return sup.wait()
+		return spec.run(ctx, parentName, notifyChildStart)
 	}
 }
 


### PR DESCRIPTION
Closes #24 

### Developer Notes

* We modified the methods `startChildren`, `stopChildren` and `monitorLoop` to be functions instead
  
  This was necessary given the new `run` method *does not* create a `Supervisor` record from the `SupervisorSpec`, rather, it just runs the supervision loop in the same thread.

* Now the `subtree` logic uses the `run` method rather than `start` and then `wait` 

  The previous approach was spawning a newly created `Child` goroutine, that later was spawning yet another goroutine (the Supervisor loop one) and then waiting for it to finish.

  Although goroutines are cheap, they are not free!

### Acceptance Criteria

* [X] There is a single goroutine created per sub-tree
