### PR TITLE
[27] Support for Child Restart setting

### DIFF
--- a/c/types.go
+++ b/c/types.go
@@ -145,6 +145,7 @@ func (cs ChildSpec) IsWorker() bool {
 	return cs.tag == Worker
 }
 
+// GetRestart returns the Restart setting for this ChildSpec
 func (cs ChildSpec) GetRestart() Restart {
 	return cs.restart
 }

--- a/c/types.go
+++ b/c/types.go
@@ -5,9 +5,6 @@ import (
 	"time"
 )
 
-// Restart specifies when a goroutine gets restarted
-type Restart uint32
-
 // ChildTag specifies the type of Child that is running, this is a closed
 // set given we only will support workers and supervisors
 type ChildTag uint32
@@ -30,15 +27,37 @@ func (ct ChildTag) String() string {
 	}
 }
 
+// Restart specifies when a goroutine gets restarted
+type Restart uint32
+
 const (
-	// Permanent Restart = iota
-	// Temporary
+	// Permanent specifies that the goroutine should be restarted any time there
+	// is an error. If the goroutine is finished without errors, it is restarted
+	// again.
+	Permanent Restart = iota
 
 	// Transient specifies that the goroutine should be restarted if and only if
 	// the goroutine failed with an error. If the goroutine finishes without
 	// errors it is not restarted again.
-	Transient Restart = iota
+	Transient
+
+	// Temporary specifies that the goroutine should not be restarted, not even
+	// when the goroutine fails
+	Temporary
 )
+
+func (r Restart) String() string {
+	switch r {
+	case Permanent:
+		return "Permanent"
+	case Transient:
+		return "Transient"
+	case Temporary:
+		return "Temporary"
+	default:
+		return "<Unknown>"
+	}
+}
 
 // ShutdownTag specifies the type of Shutdown strategy that is used when
 // stopping a goroutine
@@ -124,6 +143,10 @@ func (cs ChildSpec) Tag() ChildTag {
 // IsWorker indicates if this child is a worker
 func (cs ChildSpec) IsWorker() bool {
 	return cs.tag == Worker
+}
+
+func (cs ChildSpec) GetRestart() Restart {
+	return cs.restart
 }
 
 // Child is the runtime representation of a Spec

--- a/s/children.go
+++ b/s/children.go
@@ -35,11 +35,11 @@ func stopChild(
 }
 
 // stopChildren is used on the shutdown of the supervisor tree, it stops
-// supChildren in the desired order. The starting argument indicates if the
+// children in the desired order. The starting argument indicates if the
 // supervision tree is starting, if that is the case, it is more permisive
-// around spec supChildren not matching one to one with it's corresponding runtime
-// supChildren, this may happen because we had a start error in the middle of
-// supervision tree initialization, and we never got to initialize all supChildren
+// around spec children not matching one to one with it's corresponding runtime
+// children, this may happen because we had a start error in the middle of
+// supervision tree initialization, and we never got to initialize all children
 // at this supervision level.
 func stopChildren(
 	spec SupervisorSpec,

--- a/s/core_test.go
+++ b/s/core_test.go
@@ -1,7 +1,7 @@
 package s_test
 
 //
-// NOTE: If you feel is counter-intuitive to have workers start before
+// NOTE: If you feel it is counter-intuitive to have workers start before
 // supervisors in the assertions bellow, check stest/README.md
 //
 

--- a/s/permanent_one_for_one_test.go
+++ b/s/permanent_one_for_one_test.go
@@ -1,7 +1,7 @@
 package s_test
 
 //
-// NOTE: If you feel is counter-intuitive to have workers start before
+// NOTE: If you feel it is counter-intuitive to have workers start before
 // supervisors in the assertions bellow, check stest/README.md
 //
 

--- a/s/permanent_one_for_one_test.go
+++ b/s/permanent_one_for_one_test.go
@@ -11,14 +11,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/capatazlib/go-capataz/c"
 	"github.com/capatazlib/go-capataz/s"
 	. "github.com/capatazlib/go-capataz/stest"
 )
 
-func TestSingleFailingChildRecovers(t *testing.T) {
+func TestPermanentOneForOneSingleFailingChildRecovers(t *testing.T) {
 	parentName := "root"
 	// Fail only one time
-	child1, startFailingChild1 := FailingChild(1, "child1")
+	child1, startFailingChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Permanent))
 
 	events, err := ObserveSupervisor(
 		context.TODO(),
@@ -57,10 +58,10 @@ func TestSingleFailingChildRecovers(t *testing.T) {
 	)
 }
 
-func TestNestedFailingChildRecovers(t *testing.T) {
+func TestPermanentOneForOneNestedFailingChildRecovers(t *testing.T) {
 	parentName := "root"
 	// Fail only one time
-	child1, startFailingChild1 := FailingChild(1, "child1")
+	child1, startFailingChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Permanent))
 	tree1 := s.New("subtree1", s.WithChildren(child1))
 
 	events, err := ObserveSupervisor(

--- a/s/permanent_one_for_one_test.go
+++ b/s/permanent_one_for_one_test.go
@@ -19,7 +19,7 @@ import (
 func TestPermanentOneForOneSingleFailingChildRecovers(t *testing.T) {
 	parentName := "root"
 	// Fail only one time
-	child1, startFailingChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Permanent))
+	child1, failChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Permanent))
 
 	events, err := ObserveSupervisor(
 		context.TODO(),
@@ -34,7 +34,7 @@ func TestPermanentOneForOneSingleFailingChildRecovers(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			startFailingChild1()
+			failChild1()
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerStarted("root/child1"))
 		},
@@ -47,7 +47,7 @@ func TestPermanentOneForOneSingleFailingChildRecovers(t *testing.T) {
 			// start children from left to right
 			WorkerStarted("root/child1"),
 			SupervisorStarted("root"),
-			// ^^^ 1) startFailingChild1 starts executing here
+			// ^^^ 1) failChild1 starts executing here
 			WorkerFailed("root/child1"),
 			// ^^^ 2) And then we see a new (re)start of it
 			WorkerStarted("root/child1"),
@@ -61,7 +61,7 @@ func TestPermanentOneForOneSingleFailingChildRecovers(t *testing.T) {
 func TestPermanentOneForOneNestedFailingChildRecovers(t *testing.T) {
 	parentName := "root"
 	// Fail only one time
-	child1, startFailingChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Permanent))
+	child1, failChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Permanent))
 	tree1 := s.New("subtree1", s.WithChildren(child1))
 
 	events, err := ObserveSupervisor(
@@ -75,7 +75,7 @@ func TestPermanentOneForOneNestedFailingChildRecovers(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			startFailingChild1()
+			failChild1()
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
 		},
@@ -91,7 +91,7 @@ func TestPermanentOneForOneNestedFailingChildRecovers(t *testing.T) {
 			SupervisorStarted("root"),
 			// ^^^ 1) Wait till root starts
 			WorkerFailed("root/subtree1/child1"),
-			// ^^^ 2) We see the startFailingChild1 causing the error
+			// ^^^ 2) We see the failChild1 causing the error
 			WorkerStarted("root/subtree1/child1"),
 			// ^^^ 3) After 1st (re)start we stop
 			WorkerStopped("root/subtree1/child1"),

--- a/s/start.go
+++ b/s/start.go
@@ -177,7 +177,7 @@ func handleChildNotification(
 	)
 }
 
-// runMonitorLoop does the initialization of supervisor's supChildren and then runs
+// runMonitorLoop does the initialization of supervisor's children and then runs
 // an infinite loop that monitors each child error.
 //
 // This function is used for both async and sync strategies, given this, we
@@ -218,7 +218,7 @@ func runMonitorLoop(
 	eventNotifier := supSpec.getEventNotifier()
 	eventNotifier.SupervisorStarted(supRuntimeName, supStartTime)
 
-	/// Once supChildren have been spawned, we notify to the caller thread that the
+	/// Once children have been spawned, we notify to the caller thread that the
 	// main loop has started without errors.
 	onStart(nil)
 
@@ -228,7 +228,7 @@ func runMonitorLoop(
 		// parent context is done
 		case <-ctx.Done():
 			supChildErrMap := stopChildren(supSpec, supChildren, false /* starting? */)
-			// If any of the supChildren fails to stop, we should report that as an
+			// If any of the children fails to stop, we should report that as an
 			// error
 			if len(supChildErrMap) > 0 {
 				// On async strategy, we notify that the spawner terminated with an

--- a/s/start.go
+++ b/s/start.go
@@ -166,15 +166,15 @@ func handleChildNotification(
 			oldChild,
 			chErr,
 		)
-	} else {
-		return handleChildCompletion(
-			eventNotifier,
-			supRuntimeName,
-			supChildren,
-			supNotifyCh,
-			oldChild,
-		)
 	}
+
+	return handleChildCompletion(
+		eventNotifier,
+		supRuntimeName,
+		supChildren,
+		supNotifyCh,
+		oldChild,
+	)
 }
 
 // runMonitorLoop does the initialization of supervisor's children and then runs

--- a/s/start.go
+++ b/s/start.go
@@ -131,15 +131,13 @@ func handleChildCompletion(
 	default: /* Permanent */
 		// On child completion, the supervisor still restart the child when the
 		// c.Restart is Permanent
-		for {
-			return oneForOneRestartLoop(
-				eventNotifier,
-				supRuntimeName,
-				supChildren,
-				supNotifyCh,
-				prevChild,
-			)
-		}
+		return oneForOneRestartLoop(
+			eventNotifier,
+			supRuntimeName,
+			supChildren,
+			supNotifyCh,
+			prevChild,
+		)
 	}
 }
 

--- a/s/start.go
+++ b/s/start.go
@@ -96,15 +96,13 @@ func handleChildError(
 	case c.Permanent, c.Transient:
 		// On error scenarios, Permanent and Transient try as much as possible
 		// to restart the failing child
-		for {
-			return oneForOneRestartLoop(
-				eventNotifier,
-				supRuntimeName,
-				supChildren,
-				supNotifyCh,
-				prevChild,
-			)
-		}
+		return oneForOneRestartLoop(
+			eventNotifier,
+			supRuntimeName,
+			supChildren,
+			supNotifyCh,
+			prevChild,
+		)
 
 	default: /* Temporary */
 		// Temporary children can complete or fail, supervisor will not restart them

--- a/s/temporary_one_for_one_test.go
+++ b/s/temporary_one_for_one_test.go
@@ -1,7 +1,7 @@
 package s_test
 
 //
-// NOTE: If you feel is counter-intuitive to have workers start before
+// NOTE: If you feel it is counter-intuitive to have workers start before
 // supervisors in the assertions bellow, check stest/README.md
 //
 

--- a/s/temporary_one_for_one_test.go
+++ b/s/temporary_one_for_one_test.go
@@ -1,0 +1,175 @@
+package s_test
+
+//
+// NOTE: If you feel is counter-intuitive to have workers start before
+// supervisors in the assertions bellow, check stest/README.md
+//
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/c"
+	"github.com/capatazlib/go-capataz/s"
+	. "github.com/capatazlib/go-capataz/stest"
+)
+
+func TestTemporaryOneForOneSingleFailingChildDoesNotRecover(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1, failChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Temporary))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{
+			s.WithChildren(child1),
+		},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			failChild1()
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerFailed("root/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			SupervisorStarted("root"),
+			// ^^^ 1) failChild1 starts executing here
+			WorkerFailed("root/child1"),
+			// ^^^ 2) We see the failure, and then nothing else of this child
+			SupervisorStopped("root"),
+		},
+	)
+}
+
+func TestTemporaryOneForOneNestedFailingChildDoesNotRecover(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1, failChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Temporary))
+	tree1 := s.New("subtree1", s.WithChildren(child1))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{s.WithSubtree(tree1)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			failChild1()
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerFailed("root/subtree1/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ 1) Wait till root starts
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ 2) We see the failure, and then nothing else of this child
+			SupervisorStopped("root/subtree1"),
+			SupervisorStopped("root"),
+		},
+	)
+}
+
+func TestTemporaryOneForOneSingleCompleteChildDoesNotRestart(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1, completeChild1 := CompleteOnSignalChild("child1", c.WithRestart(c.Temporary))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{
+			s.WithChildren(child1),
+		},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the complete behavior of child1
+			completeChild1()
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerCompleted("root/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			SupervisorStarted("root"),
+			// ^^^ 1) completeChild1 starts executing here
+			WorkerCompleted("root/child1"),
+			// ^^^ 2) We see completion, and then nothing else of this child
+			SupervisorStopped("root"),
+		},
+	)
+}
+
+func TestTemporaryOneForOneNestedCompleteChildDoesNotRestart(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1, completeChild1 := CompleteOnSignalChild("child1", c.WithRestart(c.Temporary))
+	tree1 := s.New("subtree1", s.WithChildren(child1))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{s.WithSubtree(tree1)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			completeChild1()
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerCompleted("root/subtree1/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ 1) completeChild1 starts executing here
+			WorkerCompleted("root/subtree1/child1"),
+			// ^^^ 2) We see completion, and then nothing else of this child
+			SupervisorStopped("root/subtree1"),
+			SupervisorStopped("root"),
+		},
+	)
+}

--- a/s/transient_one_for_one_test.go
+++ b/s/transient_one_for_one_test.go
@@ -1,7 +1,7 @@
 package s_test
 
 //
-// NOTE: If you feel is counter-intuitive to have workers start before
+// NOTE: If you feel it is counter-intuitive to have workers start before
 // supervisors in the assertions bellow, check stest/README.md
 //
 

--- a/s/transient_one_for_one_test.go
+++ b/s/transient_one_for_one_test.go
@@ -1,0 +1,180 @@
+package s_test
+
+//
+// NOTE: If you feel is counter-intuitive to have workers start before
+// supervisors in the assertions bellow, check stest/README.md
+//
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/c"
+	"github.com/capatazlib/go-capataz/s"
+	. "github.com/capatazlib/go-capataz/stest"
+)
+
+func TestTransientOneForOneSingleFailingChildRecovers(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1, startFailingChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Transient))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{
+			s.WithChildren(child1),
+		},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			startFailingChild1()
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerStarted("root/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			SupervisorStarted("root"),
+			// ^^^ 1) startFailingChild1 starts executing here
+			WorkerFailed("root/child1"),
+			// ^^^ 2) And then we see a new (re)start of it
+			WorkerStarted("root/child1"),
+			// ^^^ 3) After 1st (re)start we stop
+			WorkerStopped("root/child1"),
+			SupervisorStopped("root"),
+		},
+	)
+}
+
+func TestTransientOneForOneNestedFailingChildRecovers(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1, startFailingChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Transient))
+	tree1 := s.New("subtree1", s.WithChildren(child1))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{s.WithSubtree(tree1)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			startFailingChild1()
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ 1) Wait till root starts
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ 2) We see the startFailingChild1 causing the error
+			WorkerStarted("root/subtree1/child1"),
+			// ^^^ 3) After 1st (re)start we stop
+			WorkerStopped("root/subtree1/child1"),
+			SupervisorStopped("root/subtree1"),
+			SupervisorStopped("root"),
+		},
+	)
+}
+
+func TestTransientOneForOneSingleCompleteChild(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1, completeChild1 := CompleteOnSignalChild("child1", c.WithRestart(c.Transient))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{
+			s.WithChildren(child1),
+		},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the complete behavior of child1
+			completeChild1()
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerCompleted("root/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			SupervisorStarted("root"),
+			// ^^^ completeChild1 starts executing here
+			WorkerCompleted("root/child1"),
+			SupervisorStopped("root"),
+		},
+	)
+}
+
+func TestTransientOneForOneNestedCompleteChild(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1, completeChild1 := CompleteOnSignalChild("child1", c.WithRestart(c.Transient))
+	tree1 := s.New("subtree1", s.WithChildren(child1))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{s.WithSubtree(tree1)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			completeChild1()
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerCompleted("root/subtree1/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ 1) Wait till root starts
+			WorkerCompleted("root/subtree1/child1"),
+			// ^^^ 2) We see the completeChild1 causing the completion
+			SupervisorStopped("root/subtree1"),
+			SupervisorStopped("root"),
+		},
+	)
+}

--- a/s/transient_one_for_one_test.go
+++ b/s/transient_one_for_one_test.go
@@ -19,7 +19,7 @@ import (
 func TestTransientOneForOneSingleFailingChildRecovers(t *testing.T) {
 	parentName := "root"
 	// Fail only one time
-	child1, startFailingChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Transient))
+	child1, failChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Transient))
 
 	events, err := ObserveSupervisor(
 		context.TODO(),
@@ -34,7 +34,7 @@ func TestTransientOneForOneSingleFailingChildRecovers(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			startFailingChild1()
+			failChild1()
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerStarted("root/child1"))
 		},
@@ -47,7 +47,7 @@ func TestTransientOneForOneSingleFailingChildRecovers(t *testing.T) {
 			// start children from left to right
 			WorkerStarted("root/child1"),
 			SupervisorStarted("root"),
-			// ^^^ 1) startFailingChild1 starts executing here
+			// ^^^ 1) failChild1 starts executing here
 			WorkerFailed("root/child1"),
 			// ^^^ 2) And then we see a new (re)start of it
 			WorkerStarted("root/child1"),
@@ -61,7 +61,7 @@ func TestTransientOneForOneSingleFailingChildRecovers(t *testing.T) {
 func TestTransientOneForOneNestedFailingChildRecovers(t *testing.T) {
 	parentName := "root"
 	// Fail only one time
-	child1, startFailingChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Transient))
+	child1, failChild1 := FailOnSignalChild(1, "child1", c.WithRestart(c.Transient))
 	tree1 := s.New("subtree1", s.WithChildren(child1))
 
 	events, err := ObserveSupervisor(
@@ -75,7 +75,7 @@ func TestTransientOneForOneNestedFailingChildRecovers(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			startFailingChild1()
+			failChild1()
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
 		},
@@ -91,7 +91,7 @@ func TestTransientOneForOneNestedFailingChildRecovers(t *testing.T) {
 			SupervisorStarted("root"),
 			// ^^^ 1) Wait till root starts
 			WorkerFailed("root/subtree1/child1"),
-			// ^^^ 2) We see the startFailingChild1 causing the error
+			// ^^^ 2) We see the failChild1 causing the error
 			WorkerStarted("root/subtree1/child1"),
 			// ^^^ 3) After 1st (re)start we stop
 			WorkerStopped("root/subtree1/child1"),

--- a/s/types.go
+++ b/s/types.go
@@ -79,6 +79,8 @@ const (
 	ProcessStartFailed
 	// ProcessFailed is an Event that indicates a process reported an error
 	ProcessFailed
+	// ProcessCompleted is an Event that indicates a process finished without errors
+	ProcessCompleted
 )
 
 // String returns a string representation of the current EventTag
@@ -92,6 +94,8 @@ func (tag EventTag) String() string {
 		return "ProcessStartFailed"
 	case ProcessFailed:
 		return "ProcessFailed"
+	case ProcessCompleted:
+		return "ProcessCompleted"
 	default:
 		return "<Unknown>"
 	}
@@ -193,6 +197,15 @@ func (en EventNotifier) ProcessFailed(
 // SupervisorFailed reports an event with an EventTag of ProcessFailed
 func (en EventNotifier) SupervisorFailed(name string, err error) {
 	en.ProcessFailed(c.Supervisor, name, err)
+}
+
+// WorkerCompleted reports an event with an EventTag of ProcessCompleted
+func (en EventNotifier) WorkerCompleted(name string) {
+	en(Event{
+		tag:                ProcessCompleted,
+		childTag:           c.Worker,
+		processRuntimeName: name,
+	})
 }
 
 // WorkerFailed reports an event with an EventTag of ProcessFailed

--- a/stest/README.md
+++ b/stest/README.md
@@ -15,7 +15,7 @@ The different known children builders are:
 
 * `WaitDoneChild`
 * `FailStartChild`
-* `FailingChild`
+* `FailOnSignalChild`
 * `NeverStopChild`
 
 All of them always return a `ChildSpec` with some expected behavior. In some

--- a/stest/assertions.go
+++ b/stest/assertions.go
@@ -238,11 +238,11 @@ func ObserveSupervisor(
 	opts := append([]s.Opt{
 		s.WithNotifier(evManager.EventCollector(ctx)),
 	}, opts0...)
-	spec := s.New(rootName, opts...)
+	supSpec := s.New(rootName, opts...)
 
 	// We always want to start the supervisor for test purposes, so this is
 	// embedded in the ObserveSupervisor call
-	sup, err := spec.Start(ctx)
+	sup, err := supSpec.Start(ctx)
 
 	evIt := evManager.Iterator()
 

--- a/stest/assertions.go
+++ b/stest/assertions.go
@@ -180,11 +180,11 @@ func NeverStopChild(name string) c.ChildSpec {
 	return cspec
 }
 
-// FailingChild creates a `c.ChildSpec` that runs a goroutine that will fail at
-// least the given number of times. Once this number of times has been reached,
-// it waits until the given `context.Done` channel indicates a supervisor
-// termination
-func FailingChild(totalErrCount int32, name string) (c.ChildSpec, func()) {
+// FailOnSignalChild creates a `c.ChildSpec` that runs a goroutine that will fail at
+// least the given number of times as soon as the returned start signal is
+// called. Once this number of times has been reached, it waits until the given
+// `context.Done` channel indicates a supervisor termination.
+func FailOnSignalChild(totalErrCount int32, name string, opts ...c.Opt) (c.ChildSpec, func()) {
 	currentFailCount := int32(0)
 	startCh := make(chan struct{})
 	startSignal := func() { close(startCh) }
@@ -199,6 +199,22 @@ func FailingChild(totalErrCount int32, name string) (c.ChildSpec, func()) {
 			<-ctx.Done()
 			return nil
 		},
+		opts...,
+	), startSignal
+}
+
+// FailOnSignalChild creates a `c.ChildSpec` that runs a goroutine that will complete at
+// at as soon as the returned start signal is called.
+func CompleteOnSignalChild(name string, opts ...c.Opt) (c.ChildSpec, func()) {
+	startCh := make(chan struct{})
+	startSignal := func() { close(startCh) }
+	return c.New(
+		name,
+		func(ctx context.Context) error {
+			<-startCh
+			return nil
+		},
+		opts...,
 	), startSignal
 }
 

--- a/stest/assertions.go
+++ b/stest/assertions.go
@@ -203,7 +203,7 @@ func FailOnSignalChild(totalErrCount int32, name string, opts ...c.Opt) (c.Child
 	), startSignal
 }
 
-// FailOnSignalChild creates a `c.ChildSpec` that runs a goroutine that will complete at
+// CompleteOnSignalChild creates a `c.ChildSpec` that runs a goroutine that will complete at
 // at as soon as the returned start signal is called.
 func CompleteOnSignalChild(name string, opts ...c.Opt) (c.ChildSpec, func()) {
 	startCh := make(chan struct{})

--- a/stest/eventp.go
+++ b/stest/eventp.go
@@ -126,6 +126,18 @@ func WorkerStarted(name string) EventP {
 	}
 }
 
+// WorkerStarted is a predicate to assert an event represents a worker process
+// that got completed
+func WorkerCompleted(name string) EventP {
+	return AndP{
+		preds: []EventP{
+			EventTagP{tag: s.ProcessCompleted},
+			ProcessNameP{name: name},
+			ProcessChildTagP{childTag: c.Worker},
+		},
+	}
+}
+
 // SupervisorStopped is a predicate to assert an event represents a process that
 // got stopped by its parent supervisor
 func SupervisorStopped(name string) EventP {

--- a/stest/eventp.go
+++ b/stest/eventp.go
@@ -126,7 +126,7 @@ func WorkerStarted(name string) EventP {
 	}
 }
 
-// WorkerStarted is a predicate to assert an event represents a worker process
+// WorkerCompleted is a predicate to assert an event represents a worker process
 // that got completed
 func WorkerCompleted(name string) EventP {
 	return AndP{


### PR DESCRIPTION
Closes #27 

### Acceptance Criteria

* [x] The one_for_one tests are replicated for each child `Restart` setting
* [x] A `Permanent` restart setting always restarts (even in goroutine completion without errors)
* [x] A `Transient` restart setting restarts a goroutine in an error scenario only (no restart on goroutine completions)
* [x] A `Temporary` restart setting behaves the same way as a `go` statement (ignores errors/completion)