### PR TITLE
Support for error threhsold tolerance functionality

### DIFF
--- a/c/err_tolerance.go
+++ b/c/err_tolerance.go
@@ -1,0 +1,48 @@
+package c
+
+import "time"
+
+type errToleranceResult uint32
+
+const (
+	errToleranceSurpassed = iota
+	increaseErrCount
+	resetErrCount
+)
+
+func (etr errToleranceResult) String() string {
+	switch etr {
+	case errToleranceSurpassed:
+		return "errToleranceSurpassed"
+	case increaseErrCount:
+		return "increaseErrCount"
+	case resetErrCount:
+		return "resetErrCount"
+	default:
+		return "<Unknown errToleranceResult>"
+	}
+}
+
+type errTolerance struct {
+	maxErrCount uint32
+	errWindow   time.Duration
+}
+
+func (et errTolerance) isWithinErrorWindow(createdAt time.Time) bool {
+	// when errWindow is 0, it means we never forget errors happened
+	return time.Since(createdAt) < et.errWindow || et.errWindow == 0
+}
+
+func (et errTolerance) didSurpassErrorCount(restartCount uint32) bool {
+	return et.maxErrCount < restartCount
+}
+
+func (et errTolerance) check(restartCount uint32, createdAt time.Time) errToleranceResult {
+	if et.isWithinErrorWindow(createdAt) {
+		if et.didSurpassErrorCount(restartCount + 1) {
+			return errToleranceSurpassed
+		}
+		return increaseErrCount
+	}
+	return resetErrCount
+}

--- a/c/err_tolerance_internal_test.go
+++ b/c/err_tolerance_internal_test.go
@@ -1,0 +1,59 @@
+package c
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrTolerance(t *testing.T) {
+	for _, tc := range []struct {
+		desc        string
+		maxErrCount uint32
+		errWindow   time.Duration
+		errCount    uint32
+		createdAt   time.Time
+		result      errToleranceResult
+	}{
+		{
+			desc: "zero window tolerance means we never forget errors",
+			// spec: two errors on a zero window
+			maxErrCount: 2,
+			errWindow:   0,
+			// input
+			errCount:  2,
+			createdAt: time.Now(),
+
+			result: errToleranceSurpassed,
+		},
+		{
+			desc: "when err count is >= than maxErrCount after window has passed",
+			// spec: two errors on a zero window
+			maxErrCount: 2,
+			errWindow:   5 * time.Second,
+			// input
+			errCount:  2,
+			createdAt: time.Now().Add(time.Duration(-6) * time.Second), /* 6 seconds ago */
+
+			result: resetErrCount,
+		},
+		{
+			desc: "when err count is <= than maxErrCount whithin err window count",
+			// spec: two errors on a zero window
+			maxErrCount: 2,
+			errWindow:   5 * time.Second,
+			// input
+			errCount:  1,
+			createdAt: time.Now().Add(time.Duration(4) * time.Second), /* 4 seconds ago */
+
+			result: increaseErrCount,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			et := errTolerance{maxErrCount: tc.maxErrCount, errWindow: tc.errWindow}
+			result := et.check(tc.errCount, tc.createdAt)
+			require.True(t, tc.result == result, result.String())
+		})
+	}
+}

--- a/c/types.go
+++ b/c/types.go
@@ -129,13 +129,11 @@ type NotifyStartFn = func(startError)
 // this changes, we may consider a design where we have a ChildSpec interface
 // and we have different implementations.
 type ChildSpec struct {
-	name     string
-	tag      ChildTag
-	shutdown Shutdown
-	restart  Restart
-
-	thresholdErrCount    uint32
-	thresholdErrDuration time.Duration
+	name         string
+	tag          ChildTag
+	shutdown     Shutdown
+	restart      Restart
+	errTolerance errTolerance
 
 	start func(context.Context, NotifyStartFn) error
 }
@@ -220,10 +218,10 @@ func (ce ChildNotification) Unwrap() error {
 // restarted a child so many times over a period of time that it does not make
 // sense to keep restarting.
 type ErrorToleranceReached struct {
-	failedChildName                 string
-	failedChildThresholdErrCount    uint32
-	failedChildThresholdErrDuration time.Duration
-	err                             error
+	failedChildName        string
+	failedChildErrCount    uint32
+	failedChildErrDuration time.Duration
+	err                    error
 }
 
 func (err *ErrorToleranceReached) String() string {

--- a/c/types.go
+++ b/c/types.go
@@ -2,6 +2,7 @@ package c
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -132,7 +133,11 @@ type ChildSpec struct {
 	tag      ChildTag
 	shutdown Shutdown
 	restart  Restart
-	start    func(context.Context, NotifyStartFn) error
+
+	thresholdErrCount    uint32
+	thresholdErrDuration time.Duration
+
+	start func(context.Context, NotifyStartFn) error
 }
 
 // Tag returns the ChildTag of this ChildSpec
@@ -155,6 +160,7 @@ type Child struct {
 	runtimeName  string
 	spec         ChildSpec
 	restartCount uint32
+	createdAt    time.Time
 	cancel       func()
 	wait         func(Shutdown) error
 }
@@ -208,4 +214,26 @@ func (ce ChildNotification) RuntimeName() string {
 // Unwrap returns the error reported by ChildNotification, if any.
 func (ce ChildNotification) Unwrap() error {
 	return ce.err
+}
+
+// ErrorToleranceReached is an error that gets reported when a supervisor has
+// restarted a child so many times over a period of time that it does not make
+// sense to keep restarting.
+type ErrorToleranceReached struct {
+	failedChildName                 string
+	failedChildThresholdErrCount    uint32
+	failedChildThresholdErrDuration time.Duration
+	err                             error
+}
+
+func (err *ErrorToleranceReached) String() string {
+	return fmt.Sprintf("Child failures surpassed error tolerance")
+}
+
+func (err *ErrorToleranceReached) Error() string {
+	return err.String()
+}
+
+func (err *ErrorToleranceReached) Unwrap() error {
+	return err.err
 }

--- a/c/types.go
+++ b/c/types.go
@@ -234,6 +234,8 @@ func (err *ErrorToleranceReached) Error() string {
 	return err.String()
 }
 
+// Unwrap returns the last error that caused the creation of an
+// ErrorToleranceReached error
 func (err *ErrorToleranceReached) Unwrap() error {
 	return err.err
 }

--- a/s/core.go
+++ b/s/core.go
@@ -75,14 +75,14 @@ func (spec SupervisorSpec) Name() string {
 func (sup Supervisor) Stop() error {
 	stopingTime := time.Now()
 	sup.cancel()
-	err := sup.wait(stopingTime, nil /* stopingErr */)
+	err := sup.wait(stopingTime, nil /* no startErr */)
 	return err
 }
 
 // Wait blocks the execution of the current goroutine until the Supervisor
 // finishes it execution.
 func (sup Supervisor) Wait() error {
-	return sup.wait(time.Time{}, nil /* stopingErr */)
+	return sup.wait(time.Time{}, nil /* no startErr */)
 }
 
 // Name returns the name of the Spec used to start this Supervisor

--- a/s/permanent_one_for_one_test.go
+++ b/s/permanent_one_for_one_test.go
@@ -8,6 +8,7 @@ package s_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -34,7 +35,7 @@ func TestPermanentOneForOneSingleFailingChildRecovers(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			failChild1()
+			failChild1(true /* done */)
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerStarted("root/child1"))
 		},
@@ -75,7 +76,7 @@ func TestPermanentOneForOneNestedFailingChildRecovers(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			failChild1()
+			failChild1(true /* done */)
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
 		},
@@ -94,6 +95,230 @@ func TestPermanentOneForOneNestedFailingChildRecovers(t *testing.T) {
 			// ^^^ 2) We see the failChild1 causing the error
 			WorkerStarted("root/subtree1/child1"),
 			// ^^^ 3) After 1st (re)start we stop
+			WorkerStopped("root/subtree1/child1"),
+			SupervisorStopped("root/subtree1"),
+			SupervisorStopped("root"),
+		},
+	)
+}
+
+func TestPermanentOneForOneSingleFailingChildReachThreshold(t *testing.T) {
+	parentName := "root"
+	child1, failChild1 := FailOnSignalChild(
+		3,
+		"child1",
+		c.WithRestart(c.Permanent),
+		c.WithTolerance(2, 10*time.Second),
+	)
+	child2 := WaitDoneChild("child2")
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{
+			s.WithChildren(child1, child2),
+		},
+		func(em EventManager) {
+			evIt := em.Iterator()
+
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/child1"))
+			// ^^^ Wait till first restart
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/child1"))
+			// ^^^ Wait till second restart
+
+			failChild1(true /* done */)
+			evIt.SkipTill(WorkerFailed("root/child1"))
+			// ^^^ Wait till third failure
+		},
+	)
+
+	// This should return an error given there is no other supervisor that will
+	// rescue us when error threshold reached in a child.
+	assert.Error(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			SupervisorStarted("root"),
+			// ^^^ failChild1 starts executing here
+
+			WorkerFailed("root/child1"),
+			WorkerStarted("root/child1"),
+			// ^^^ first restart
+
+			WorkerFailed("root/child1"),
+			WorkerStarted("root/child1"),
+			// ^^^ second restart
+
+			// 3rd err
+			WorkerFailed("root/child1"),
+			WorkerFailed("root/child1"),
+			// ^^^ Error that indicates treshold has been met
+
+			WorkerStopped("root/child2"),
+			// ^^^ Stopping all other workers because supervisor failed
+
+			SupervisorFailed("root"),
+			// ^^^ Finish with SupervisorFailed because no parent supervisor will
+			// recover it
+		},
+	)
+}
+
+func TestPermanentOneForOneNestedFailingChildReachThreshold(t *testing.T) {
+	parentName := "root"
+	child1, failChild1 := FailOnSignalChild(
+		3, // 3 errors, 2 tolerance
+		"child1",
+		c.WithRestart(c.Permanent),
+		c.WithTolerance(2, 10*time.Second),
+	)
+	child2 := WaitDoneChild("child2")
+	tree1 := s.New("subtree1", s.WithChildren(child1, child2))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{s.WithSubtree(tree1)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
+			// ^^^ Wait till first restart
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
+			// ^^^ Wait till second restart
+
+			failChild1(true /* done */) // 3 failures
+			evIt.SkipTill(WorkerFailed("root/subtree1/child1"))
+			// ^^^ Wait till worker failure
+
+			evIt.SkipTill(SupervisorFailed("root/subtree1"))
+			// ^^^ Wait till supervisor failure (no more WorkerStarted)
+			evIt.SkipTill(SupervisorStarted("root/subtree1"))
+			// ^^^ Wait till supervisor restarted
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ Wait till root starts
+
+			// 1st err
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ We see failChild1 causing the error
+			WorkerStarted("root/subtree1/child1"),
+			// ^^^ Wait failChild1 restarts
+
+			// 2nd err
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ After 1st (re)start we stop
+			WorkerStarted("root/subtree1/child1"),
+			// ^^^ Wait failChild1 restarts (2nd)
+
+			// 3rd err
+			WorkerFailed("root/subtree1/child1"),
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ Error that indicates treshold has been met
+
+			WorkerStopped("root/subtree1/child2"),
+			// ^^^ IMPORTANT: Supervisor failure stops other children
+			SupervisorFailed("root/subtree1"),
+			// ^^^ Supervisor child surpassed error
+
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			// ^^^ IMPORTANT: Restarted Supervisor signals restart of child first
+			SupervisorStarted("root/subtree1"),
+			// ^^^ Supervisor restarted again
+
+			WorkerStopped("root/subtree1/child2"),
+			WorkerStopped("root/subtree1/child1"),
+			SupervisorStopped("root/subtree1"),
+			SupervisorStopped("root"),
+		},
+	)
+}
+
+func TestPermanentOneForOneNestedFailingChildErrorCountResets(t *testing.T) {
+	parentName := "root"
+	child1, failChild1 := FailOnSignalChild(
+		2, // 3 errors, 2 tolerance
+		"child1",
+		c.WithRestart(c.Permanent),
+		c.WithTolerance(1, 100*time.Microsecond),
+	)
+	child2 := WaitDoneChild("child2")
+	tree1 := s.New("subtree1", s.WithChildren(child1, child2))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{s.WithSubtree(tree1)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
+			// ^^^ Wait till first restart
+
+			// Waiting 3 times more than tolerance window
+			time.Sleep(300 * time.Microsecond)
+			failChild1(true /* done */)
+			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
+			// ^^^ Wait till second restart
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ Wait till root starts
+
+			// 1st err
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ We see failChild1 causing the error
+			WorkerStarted("root/subtree1/child1"),
+			// ^^^ Wait failChild1 restarts
+
+			// 2nd err -- even though we only tolerate one error, the second error happens
+			// after the 100 microseconds window, and it restarts
+			WorkerFailed("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child1"),
+			// ^^^ Wait failChild1 restarts (2nd)
+
+			WorkerStopped("root/subtree1/child2"),
 			WorkerStopped("root/subtree1/child1"),
 			SupervisorStopped("root/subtree1"),
 			SupervisorStopped("root"),

--- a/s/permanent_one_for_one_test.go
+++ b/s/permanent_one_for_one_test.go
@@ -160,7 +160,6 @@ func TestPermanentOneForOneSingleFailingChildReachThreshold(t *testing.T) {
 
 			// 3rd err
 			WorkerFailed("root/child1"),
-			WorkerFailed("root/child1"),
 			// ^^^ Error that indicates treshold has been met
 
 			WorkerStopped("root/child2"),
@@ -238,7 +237,6 @@ func TestPermanentOneForOneNestedFailingChildReachThreshold(t *testing.T) {
 			// ^^^ Wait failChild1 restarts (2nd)
 
 			// 3rd err
-			WorkerFailed("root/subtree1/child1"),
 			WorkerFailed("root/subtree1/child1"),
 			// ^^^ Error that indicates treshold has been met
 

--- a/s/start.go
+++ b/s/start.go
@@ -35,12 +35,6 @@ func oneForOneRestart(
 	newChild, restartErr := prevChild.Restart(supRuntimeName, supNotifyCh)
 
 	if restartErr != nil {
-		// Given this error ocurred after supervisor bootstrap, it is treated as the
-		// child failed on supervision time, _not_ start time; return the error so that
-		// the supervisor does the restarting
-		if prevChild.Tag() == c.Worker {
-			eventNotifier.WorkerFailed(prevChild.RuntimeName(), restartErr)
-		}
 		return c.Child{}, restartErr
 	}
 

--- a/s/subtree.go
+++ b/s/subtree.go
@@ -4,6 +4,7 @@ package s
 
 import (
 	"context"
+	"time"
 
 	"github.com/capatazlib/go-capataz/c"
 )
@@ -42,6 +43,7 @@ func (spec SupervisorSpec) subtree(
 		copts0,
 		c.WithShutdown(c.Inf),
 		c.WithTag(c.Supervisor),
+		c.WithTolerance(1, 5*time.Second),
 	)
 
 	return c.NewWithNotifyStart(

--- a/s/subtree.go
+++ b/s/subtree.go
@@ -12,7 +12,7 @@ import (
 // sub-tree. It returns an error if the child supervisor fails to start.
 func subtreeMain(
 	parentName string,
-	spec SupervisorSpec,
+	supSpec SupervisorSpec,
 ) func(context.Context, c.NotifyStartFn) error {
 	// we use the start version that receives the notifyChildStart callback, this
 	// is essential, as we need this callback to signal the sub-tree children have
@@ -22,7 +22,7 @@ func subtreeMain(
 		// to spawn yet another goroutine
 		ctx, cancelFn := context.WithCancel(parentCtx)
 		defer cancelFn()
-		return spec.run(ctx, parentName, notifyChildStart)
+		return supSpec.run(ctx, parentName, notifyChildStart)
 	}
 }
 

--- a/s/temporary_one_for_one_test.go
+++ b/s/temporary_one_for_one_test.go
@@ -34,7 +34,7 @@ func TestTemporaryOneForOneSingleFailingChildDoesNotRecover(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			failChild1()
+			failChild1(true /* done */)
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerFailed("root/child1"))
 		},
@@ -72,7 +72,7 @@ func TestTemporaryOneForOneNestedFailingChildDoesNotRecover(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			failChild1()
+			failChild1(true /* done */)
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerFailed("root/subtree1/child1"))
 		},

--- a/s/transient_one_for_one_test.go
+++ b/s/transient_one_for_one_test.go
@@ -238,7 +238,6 @@ func TestTransientOneForOneSingleFailingChildReachThreshold(t *testing.T) {
 
 			// 3rd err
 			WorkerFailed("root/child1"),
-			WorkerFailed("root/child1"),
 			// ^^^ Error that indicates treshold has been met
 
 			WorkerStopped("root/child2"),
@@ -316,7 +315,6 @@ func TestTransientOneForOneNestedFailingChildReachThreshold(t *testing.T) {
 			// ^^^ Wait failChild1 restarts (2nd)
 
 			// 3rd err
-			WorkerFailed("root/subtree1/child1"),
 			WorkerFailed("root/subtree1/child1"),
 			// ^^^ Error that indicates treshold has been met
 

--- a/s/transient_one_for_one_test.go
+++ b/s/transient_one_for_one_test.go
@@ -8,6 +8,7 @@ package s_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -34,7 +35,7 @@ func TestTransientOneForOneSingleFailingChildRecovers(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			failChild1()
+			failChild1(true /* done */)
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerStarted("root/child1"))
 		},
@@ -75,7 +76,7 @@ func TestTransientOneForOneNestedFailingChildRecovers(t *testing.T) {
 			// 1) Wait till all the tree is up
 			evIt.SkipTill(SupervisorStarted("root"))
 			// 2) Start the failing behavior of child1
-			failChild1()
+			failChild1(true /* done */)
 			// 3) Wait till first restart
 			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
 		},
@@ -177,4 +178,164 @@ func TestTransientOneForOneNestedCompleteChild(t *testing.T) {
 			SupervisorStopped("root"),
 		},
 	)
+}
+
+func TestTransientOneForOneSingleFailingChildReachThreshold(t *testing.T) {
+	parentName := "root"
+	child1, failChild1 := FailOnSignalChild(
+		3,
+		"child1",
+		c.WithRestart(c.Transient),
+		c.WithTolerance(2, 10*time.Second),
+	)
+	child2 := WaitDoneChild("child2")
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{
+			s.WithChildren(child1, child2),
+		},
+		func(em EventManager) {
+			evIt := em.Iterator()
+
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/child1"))
+			// ^^^ Wait till first restart
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/child1"))
+			// ^^^ Wait till second restart
+
+			failChild1(true /* done */)
+			evIt.SkipTill(WorkerFailed("root/child1"))
+			// ^^^ Wait till third failure
+		},
+	)
+
+	// This should return an error given there is no other supervisor that will
+	// rescue us when error threshold reached in a child.
+	assert.Error(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			SupervisorStarted("root"),
+			// ^^^ failChild1 starts executing here
+
+			WorkerFailed("root/child1"),
+			WorkerStarted("root/child1"),
+			// ^^^ first restart
+
+			WorkerFailed("root/child1"),
+			WorkerStarted("root/child1"),
+			// ^^^ second restart
+
+			// 3rd err
+			WorkerFailed("root/child1"),
+			WorkerFailed("root/child1"),
+			// ^^^ Error that indicates treshold has been met
+
+			WorkerStopped("root/child2"),
+			// ^^^ Stopping all other workers because supervisor failed
+
+			SupervisorFailed("root"),
+			// ^^^ Finish with SupervisorFailed because no parent supervisor will
+			// recover it
+		},
+	)
+}
+
+func TestTransientOneForOneNestedFailingChildReachThreshold(t *testing.T) {
+	parentName := "root"
+	child1, failChild1 := FailOnSignalChild(
+		3, // 3 errors, 2 tolerance
+		"child1",
+		c.WithRestart(c.Transient),
+		c.WithTolerance(2, 10*time.Second),
+	)
+	child2 := WaitDoneChild("child2")
+	tree1 := s.New("subtree1", s.WithChildren(child1, child2))
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		[]s.Opt{s.WithSubtree(tree1)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
+			// ^^^ Wait till first restart
+
+			failChild1(false /* done */)
+			evIt.SkipTill(WorkerStarted("root/subtree1/child1"))
+			// ^^^ Wait till second restart
+
+			failChild1(true /* done */) // 3 failures
+			evIt.SkipTill(WorkerFailed("root/subtree1/child1"))
+			// ^^^ Wait till worker failure
+
+			evIt.SkipTill(SupervisorFailed("root/subtree1"))
+			// ^^^ Wait till supervisor failure (no more WorkerStarted)
+			evIt.SkipTill(SupervisorStarted("root/subtree1"))
+			// ^^^ Wait till supervisor restarted
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ Wait till root starts
+
+			// 1st err
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ We see failChild1 causing the error
+			WorkerStarted("root/subtree1/child1"),
+			// ^^^ Wait failChild1 restarts
+
+			// 2nd err
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ After 1st (re)start we stop
+			WorkerStarted("root/subtree1/child1"),
+			// ^^^ Wait failChild1 restarts (2nd)
+
+			// 3rd err
+			WorkerFailed("root/subtree1/child1"),
+			WorkerFailed("root/subtree1/child1"),
+			// ^^^ Error that indicates treshold has been met
+
+			WorkerStopped("root/subtree1/child2"),
+			// ^^^ IMPORTANT: Supervisor failure stops other children
+			SupervisorFailed("root/subtree1"),
+			// ^^^ Supervisor child surpassed error
+
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			// ^^^ IMPORTANT: Restarted Supervisor signals restart of child first
+			SupervisorStarted("root/subtree1"),
+			// ^^^ Supervisor restarted again
+
+			WorkerStopped("root/subtree1/child2"),
+			WorkerStopped("root/subtree1/child1"),
+			SupervisorStopped("root/subtree1"),
+			SupervisorStopped("root"),
+		},
+	)
+
 }

--- a/s/types.go
+++ b/s/types.go
@@ -1,6 +1,7 @@
 package s
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -142,10 +143,10 @@ func (e Event) Created() time.Time {
 func (e Event) String() string {
 	var buffer strings.Builder
 	buffer.WriteString("Event{")
-	buffer.WriteString(fmt.Sprintf("tag: %s", e.tag))
-	buffer.WriteString(fmt.Sprintf(", childTag: %s", e.childTag))
+	buffer.WriteString(fmt.Sprintf("created: %55s", e.created.String()))
+	buffer.WriteString(fmt.Sprintf(", tag: %16s", e.tag))
+	buffer.WriteString(fmt.Sprintf(", childTag: %10s", e.childTag))
 	buffer.WriteString(fmt.Sprintf(", processRuntime: %s", e.processRuntimeName))
-	buffer.WriteString(fmt.Sprintf(", created: %v", e.created))
 	if e.err != nil {
 		buffer.WriteString(fmt.Sprintf(", err: %+v", e.err))
 	}
@@ -180,6 +181,15 @@ func (en EventNotifier) SupervisorStopped(name string, stopTime time.Time) {
 	en.ProcessStopped(c.Supervisor, name, stopTime)
 }
 
+// WorkerCompleted reports an event with an EventTag of ProcessCompleted
+func (en EventNotifier) WorkerCompleted(name string) {
+	en(Event{
+		tag:                ProcessCompleted,
+		childTag:           c.Worker,
+		processRuntimeName: name,
+	})
+}
+
 // ProcessFailed reports an event with an EventTag of ProcessStartFailed
 func (en EventNotifier) ProcessFailed(
 	childTag c.ChildTag,
@@ -191,21 +201,13 @@ func (en EventNotifier) ProcessFailed(
 		childTag:           childTag,
 		processRuntimeName: name,
 		err:                err,
+		created:            time.Now(),
 	})
 }
 
 // SupervisorFailed reports an event with an EventTag of ProcessFailed
 func (en EventNotifier) SupervisorFailed(name string, err error) {
 	en.ProcessFailed(c.Supervisor, name, err)
-}
-
-// WorkerCompleted reports an event with an EventTag of ProcessCompleted
-func (en EventNotifier) WorkerCompleted(name string) {
-	en(Event{
-		tag:                ProcessCompleted,
-		childTag:           c.Worker,
-		processRuntimeName: name,
-	})
 }
 
 // WorkerFailed reports an event with an EventTag of ProcessFailed
@@ -355,3 +357,37 @@ var rootSupervisorName = ""
 // childSepToken is the token use to separate sub-trees and child names in the
 // supervision tree
 const childSepToken = "/"
+
+type supervisionError struct {
+	supRuntimeName string
+	childErr       *c.ErrorToleranceReached
+	terminateErr   terminateError
+}
+
+func (err supervisionError) String() string {
+	if err.childErr != nil && err.terminateErr != nil {
+		return fmt.Sprintf(
+			"Supervisor child surpassed error threshold, " +
+				"(and other children failed to terminate as well)",
+		)
+	} else if err.childErr != nil {
+		return fmt.Sprintf("Supervisor child surpassed error tolerance")
+	}
+	// THIS never happens, an invariant of this type is that it only gets
+	// created with a childErr
+	panic(
+		errors.New("invalid supervisionError was created"),
+	)
+}
+
+func (err supervisionError) Error() string {
+	return err.String()
+}
+
+func (err supervisionError) Unwrap() error {
+	// it should never be nil
+	if err.childErr != nil {
+		return err.childErr.Unwrap()
+	}
+	return nil
+}

--- a/s/types.go
+++ b/s/types.go
@@ -306,7 +306,7 @@ type Supervisor struct {
 	spec        SupervisorSpec
 	children    map[string]c.Child
 	cancel      func()
-	wait        func(time.Time, error) error
+	wait        func(time.Time, startError) error
 }
 
 // SupervisorError wraps an error from a children, enhancing it with supervisor
@@ -373,8 +373,9 @@ func (err supervisionError) String() string {
 	} else if err.childErr != nil {
 		return fmt.Sprintf("Supervisor child surpassed error tolerance")
 	}
-	// THIS never happens, an invariant of this type is that it only gets
-	// created with a childErr
+	// NOTE: this case never happens, an invariant condition of this type is that
+	// it only hold values with a childErr. If we are here, it means we manually
+	// created a wrong supervisionError value (implementation error).
 	panic(
 		errors.New("invalid supervisionError was created"),
 	)

--- a/s/types.go
+++ b/s/types.go
@@ -144,7 +144,7 @@ func (e Event) String() string {
 	var buffer strings.Builder
 	buffer.WriteString("Event{")
 	buffer.WriteString(fmt.Sprintf("created: %55s", e.created.String()))
-	buffer.WriteString(fmt.Sprintf(", tag: %16s", e.tag))
+	buffer.WriteString(fmt.Sprintf(", tag: %20s", e.tag))
 	buffer.WriteString(fmt.Sprintf(", childTag: %10s", e.childTag))
 	buffer.WriteString(fmt.Sprintf(", processRuntime: %s", e.processRuntimeName))
 	if e.err != nil {

--- a/stest/assertions.go
+++ b/stest/assertions.go
@@ -184,10 +184,16 @@ func NeverStopChild(name string) c.ChildSpec {
 // least the given number of times as soon as the returned start signal is
 // called. Once this number of times has been reached, it waits until the given
 // `context.Done` channel indicates a supervisor termination.
-func FailOnSignalChild(totalErrCount int32, name string, opts ...c.Opt) (c.ChildSpec, func()) {
+func FailOnSignalChild(totalErrCount int32, name string, opts ...c.Opt) (c.ChildSpec, func(bool)) {
 	currentFailCount := int32(0)
 	startCh := make(chan struct{})
-	startSignal := func() { close(startCh) }
+	startSignal := func(done bool) {
+		if done {
+			close(startCh)
+			return
+		}
+		startCh <- struct{}{}
+	}
 	return c.New(
 		name,
 		func(ctx context.Context) error {

--- a/stest/evmanager.go
+++ b/stest/evmanager.go
@@ -66,6 +66,7 @@ func (em EventManager) StartCollector(ctx context.Context) {
 // EventCollector is used as an event notifier of a supervision system
 func (em EventManager) EventCollector(ctx context.Context) func(ev s.Event) {
 	return func(ev s.Event) {
+		// NOTE: DO NOT REMOVE LINE BELLOW (debug tool)
 		// fmt.Printf("%+v\n", ev)
 		select {
 		case <-ctx.Done():

--- a/stest/evmanager.go
+++ b/stest/evmanager.go
@@ -66,6 +66,7 @@ func (em EventManager) StartCollector(ctx context.Context) {
 // EventCollector is used as an event notifier of a supervision system
 func (em EventManager) EventCollector(ctx context.Context) func(ev s.Event) {
 	return func(ev s.Event) {
+		// fmt.Printf("%+v\n", ev)
 		select {
 		case <-ctx.Done():
 		case em.evCh <- ev:


### PR DESCRIPTION
Closes #29 

### Context

The current implementation does not have a way to fail hard when children (workers and sub-trees) fail constantly. Add the ability to specify an error threshold to a supervisor to be able to tolerate errors up until a point and fail hard otherwise.

### Acceptance Criteria

* [x] The error threshold code should be the same one for all permutations of the restart child setting
* There are tests that:
  - [x] verify error threshold surpassed
  - [x] verify restarts work as long as they can before threshold is met
  - [x] supervisor failure terminates sibling children