### PR TITLE
Kaizen: Fix/Cleanup of nix setup

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -16,7 +16,7 @@ in
 { pkgs ? pinnedPkgs }:
 
 let
-  go-capataz = import ./default.nix { pkgs = pkgs; };
+  go-capataz = pkgs.callPackage ./. {};
 
 in
   pkgs.mkShell {

--- a/default.nix
+++ b/default.nix
@@ -1,31 +1,11 @@
-let
-  sources = import ./nix/sources.nix {};
-  pinnedPkgs = import sources.nixpkgs {};
+{ buildGoPackage, go, lib }:
 
-in
+assert lib.versionAtLeast go.version "1.14";
 
-{ pkgs ? pinnedPkgs }:
-
-assert pkgs.lib.versionAtLeast pkgs.go.version "1.14";
-
-pkgs.buildGoPackage rec {
+buildGoPackage rec {
   name = "go-capataz";
   version = "latest";
   goPackagePath = "github.com/capatazlib/go-capataz";
   src = ./.;
   goDeps = ./deps.nix;
 }
-
-# pkgs.buildGoModule rec {
-#   name = "go-capataz";
-#   version = "latest";
-#   src = ./.;
-#   vendorSha256 = "0zv0nfbc1qkj5jq9ax3da7g7jr1fqbb7zhy8sqis1h9jgzl06x2s";
-#   meta = with pkgs.lib; {
-#     description = "";
-#     homepage = https://github.com/capatazlib/go-capataz;
-#     license = licenses.mit;
-#     maintainers = [ "Roman Gonzalez" ];
-#     platforms = platforms.linux ++ platforms.darwin;
-#   };
-# }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,11 @@
-{ buildGoPackage, go, lib }:
+let
+  sources = import ./nix/sources.nix {};
+  pinnedPkgs = import sources.nixpkgs {};
+in
+
+{ buildGoPackage ? pinnedPkgs.buildGoPackage,
+  go             ? pinnedPkgs.go,
+  lib            ? pinnedPkgs.lib }:
 
 assert lib.versionAtLeast go.version "1.14";
 

--- a/nix/gopls/default.nix
+++ b/nix/gopls/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, go, buildGoModule, fetchgit }:
+
+buildGoModule rec {
+  pname = "gopls";
+  version = "go-capataz";
+  rev = "72e4a01eba4315301fd9ce00c8c2f492580ded8a";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://go.googlesource.com/tools";
+    sha256 = "0a8c7j4w784w441j3j3bh640vy1g6g214641qv485wyi0xj49anf";
+  };
+
+  modRoot = "./gopls";
+
+  vendorSha256 = "06w6qsya16d3zx552advlqbm1hgjqjdy765yafp8p2i2xvmgpyma";
+
+  # Set GOTOOLDIR for derivations adding this to buildInputs
+  # postInstall = ''
+  #   mkdir -p $out/nix-support
+  #   substitute ${../../go-modules/tools/setup-hook.sh} $out/nix-support/setup-hook \
+  #     --subst-var-by bin $out
+  # '';
+
+  # Do not copy this without a good reason for enabling
+  # In this case tools is heavily coupled with go itself and embeds paths.
+  allowGoReference = true;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "6d035a9d10d930d92e6016abec531e43e48a469f",
-        "sha256": "1gixzdzzsr35ni2plsj4c84g5givjd9pv6n5f4204kmq7jbnv3dr",
+        "rev": "571212eb839d482992adb05479b86eeb6a9c7b2f",
+        "sha256": "0ncsh5rkjbcdaksngmn7apiq1qhm5z1z6xa1x70svxq91znibp4f",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/6d035a9d10d930d92e6016abec531e43e48a469f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/571212eb839d482992adb05479b86eeb6a9c7b2f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,8 @@ let
   # build an overlay with specific packages from sources.nix
   overlay = _: pkgs: {
     niv = import sources.niv {};
+    # check note bellow
+    gopls = pkgs.callPackage ./nix/gopls {};
   };
 
   # get nixpkgs with pinned packages overlay
@@ -16,7 +18,6 @@ in
 { pkgs ? pinnedPkgs }:
 
 let
-
   humanlog = with pkgs; buildGoPackage rec {
     name = "humanlog";
     version = "0.2.1";
@@ -47,11 +48,17 @@ in
 
       # current go version
       go_1_14
-      go-capataz
 
       # recommended packages to have for development with emacs/spacemacs
       gotools godef gocode golint golangci-lint gogetdoc gopkgs gotests impl
       errcheck reftools humanlog delve
+
+      # NOTE: I needed to create a gopls package given gotools got broken
+      # https://github.com/NixOS/nixpkgs/issues/88716
+      gopls
+
+      # capataz deps
+      go-capataz
     ];
 
     shellHook = ''


### PR DESCRIPTION
### Improvements

* Remove pinning in the `default.nix` derivation, 
* Make `default.nix` dependencies explicit
* Bump nixpkgs version
* Add `gopls` package to overlays given the one upstream is broken