### PR TITLE
[#42] Add support for dynamic supervisors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:	## Display this message
 .DEFAULT_GOAL := help
 
 test: ## Run tests
-	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -timeout 10s -race -coverprofile=coverage.txt -covermode=atomic ./...
 .PHONY: test
 
 lint: ## Run linters

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:	## Display this message
 .DEFAULT_GOAL := help
 
 test: ## Run tests
-	go test -timeout 10s -race -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 .PHONY: test
 
 lint: ## Run linters

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -295,7 +295,7 @@ func (dyn DynSupervisor) GetName() string {
 //   list of children
 //
 func NewDynSupervisor(ctx context.Context, name string, opts ...Opt) (DynSupervisor, error) {
-	spec := NewSupervisorSpec(name, withNodes([]Node{}), opts...)
+	spec := NewSupervisorSpec(name, WithNodes(), opts...)
 	sup, err := spec.Start(ctx)
 	if err != nil {
 		return DynSupervisor{}, err

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -176,7 +176,12 @@ func (dyn *DynSupervisor) terminateNode(nodeName string) func() error {
 			return
 		}
 
-		err = <-resultCh
+		select {
+		case err = <-resultCh:
+		default:
+			// Not sure when this scenario would happen to be honest :shrug:
+			err = errors.New("could not get a cancelation confirmation from worker")
+		}
 		return
 	}
 }

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -139,7 +139,9 @@ func handleCtrlMsg(
 
 func (dyn *DynSupervisor) terminateNode(nodeName string) func() error {
 
-	resultCh := make(chan terminateError)
+	// we initialize the resultCh with a buffer of 1, we may store the result
+	// before the client is ready to read it.
+	resultCh := make(chan terminateError, 1)
 	terminatemsg := terminateChildMsg{
 		nodeName:   nodeName,
 		resultChan: resultCh,
@@ -161,7 +163,6 @@ func (dyn *DynSupervisor) terminateNode(nodeName string) func() error {
 		}()
 		// block until the supervisor can handle the request, in case the
 		// supervisor is stopped, this line is going to panic
-		// TODO: be extra paranoid and add a timeout here
 		msg := ctrlMsg{
 			tag: terminateChild,
 			msg: terminatemsg,
@@ -203,7 +204,9 @@ func (dyn *DynSupervisor) Spawn(nodeFn Node) (func() error, error) {
 		return nil, fmt.Errorf("supervisor already terminated: %w", terminationErr)
 	}
 
-	resultCh := make(chan interface{})
+	// we initialize the resultCh with a buffer of 1, we may store the result
+	// before the client is ready to read it.
+	resultCh := make(chan interface{}, 1)
 	startmsg := startChildMsg{
 		node:       nodeFn,
 		resultChan: resultCh,

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -1,0 +1,249 @@
+package cap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/capatazlib/go-capataz/internal/c"
+)
+
+// startChildMsg is a message sent from clients to tell a supervisor to spawn
+// on-demand a worker routine.
+type startChildMsg struct {
+	node Node
+	// result could either be a startError or a string with the runtime name
+	resultChan chan<- interface{}
+}
+
+// terminateChildMsg is a message sent from clients to tell a supervisor to close a
+// previously spawned worker routine.
+type terminateChildMsg struct {
+	nodeName   string
+	resultChan chan<- terminateError
+}
+
+// ctlrMsgTag tells us which control message we need to cast/handle
+type ctrlMsgTag uint32
+
+const (
+	startChild ctrlMsgTag = iota
+	terminateChild
+)
+
+// ctlrMsg is a message sent from clients to a supervisor via a public API
+// method
+type ctrlMsg struct {
+	tag ctrlMsgTag
+	msg interface{}
+}
+
+// DynSupervisor is a supervisor that can spawn workers in a procedural way.
+type DynSupervisor struct {
+	sup            Supervisor
+	terminated     bool
+	terminationErr error
+}
+
+func handleCtrlMsg(
+	eventNotifier EventNotifier,
+	supSpec SupervisorSpec,
+	supChildrenSpec []c.ChildSpec,
+	supRuntimeName string,
+	supChildren map[string]c.Child,
+	supNotifyCh chan c.ChildNotification,
+	msg ctrlMsg,
+) ([]c.ChildSpec, map[string]c.Child) {
+	switch msg.tag {
+	case startChild:
+		startcm, ok := msg.msg.(startChildMsg)
+		if !ok {
+			panic("Expected startChildMsg; got something else. Invalid Supervisor implementation")
+		}
+		childSpec := startcm.node(supSpec)
+
+		ch, startErr := startChildNode(supSpec, supRuntimeName, supNotifyCh, childSpec)
+		if startErr != nil {
+			// When we fail, we send an error to the supNotifyCh and return the error,
+			// this doesn't have any detrimental consequence in static supervisors,
+			// but on dynamic supervisors, it means the monitor loop will get bothered
+			// with an error that it should not really handle. We are going to read it
+			// out and return after that.
+			_ = <-supNotifyCh
+			// do not block waiting for a read
+			select {
+			case startcm.resultChan <- startErr:
+			default:
+			}
+
+			return supChildrenSpec, supChildren
+		}
+
+		// We store the child to the spec list because we need to terminate them
+		// when the supervisor is terminated in the correct order. This won't have
+		// unintended side-effects because a DynSupervisor once terminated, cannot
+		// be started again.
+		supChildrenSpec = append(supChildrenSpec, childSpec)
+		supChildren[ch.GetName()] = ch
+
+		select {
+		case startcm.resultChan <- ch.GetName():
+			// We return the regular name (not the runtime one), given that we store that
+			// in the childrenMap of the supervisor
+		default:
+		}
+
+		return supChildrenSpec, supChildren
+
+	case terminateChild:
+		terminatecm, ok := msg.msg.(terminateChildMsg)
+		ch, ok := supChildren[terminatecm.nodeName]
+		if !ok {
+			errMsg := fmt.Sprintf("worker %s not found", terminatecm.nodeName)
+			// do not block waiting for a read
+			select {
+			case terminatecm.resultChan <- errors.New(errMsg):
+			default:
+			}
+
+			return supChildrenSpec, supChildren
+		}
+
+		// we call our basic terminateChildNode function that is found in the
+		// monitor.go file
+		terminateErr := terminateChildNode(eventNotifier, ch)
+		// do not block waiting for a read
+		select {
+		case terminatecm.resultChan <- terminateErr:
+		default:
+		}
+
+		return supChildrenSpec, supChildren
+
+	default:
+		panic("Unknown control message received. Invalid Supervisor implementation.")
+	}
+}
+
+func (dyn *DynSupervisor) terminateNode(nodeName string) context.CancelFunc {
+	resultCh := make(chan terminateError)
+	terminatemsg := terminateChildMsg{
+		nodeName:   nodeName,
+		resultChan: resultCh,
+	}
+	return func() {
+		// block until the supervisor can handle the request, in case the
+		// supervisor is stopped, this line is going to panic
+		// TODO: be extra paranoid and add a timeout here
+		dyn.sup.ctrlCh <- ctrlMsg{
+			tag: terminateChild,
+			msg: terminatemsg,
+		}
+
+		_ = <-resultCh
+	}
+}
+
+// Spawn creates a new worker routine from the given node specification. It
+// either returns a cancel/shutdown callback or an error in the scenario the
+// start of this worker failed. This function blocks until the worker is
+// started.
+func (dyn *DynSupervisor) Spawn(nodeFn Node) (context.CancelFunc, error) {
+	// if we already registered a terminationErr, return it
+	if dyn.terminated {
+		return func() {}, fmt.Errorf("supervisor already terminated: %w", dyn.terminationErr)
+	}
+
+	// if the underlying supervisor is kaput, return the error
+	if terminationErr := dyn.sup.GetCrashError(); terminationErr != nil {
+		dyn.terminated = true
+		dyn.terminationErr = terminationErr
+		return func() {}, fmt.Errorf("supervisor already terminated: %w", terminationErr)
+	}
+
+	resultCh := make(chan interface{})
+	startmsg := startChildMsg{
+		node:       nodeFn,
+		resultChan: resultCh,
+	}
+
+	// block until the supervisor can handle the request, in case the
+	// supervisor is stopped, this line is going to panic
+	// TODO: be extra paranoid and add a timeout here
+	dyn.sup.ctrlCh <- ctrlMsg{
+		tag: startChild,
+		msg: startmsg,
+	}
+
+	// blocks until worker start, the worker already has a timeout mechanism
+	// so we rely on that to not get stuck here forever
+	result, ok := <-resultCh
+
+	if !ok {
+		panic("could not get the result of a spawn call. Implementation error")
+	}
+
+	switch v := result.(type) {
+	// successful case
+	case string:
+		return dyn.terminateNode(v), nil
+
+	// error case
+	case error:
+		return nil, v
+
+	// unknown case
+	default:
+		panic("did not get valid response value from control message. Implementation error")
+	}
+}
+
+// Terminate is a synchronous procedure that halts the execution of the whole
+// supervision tree.
+func (dyn *DynSupervisor) Terminate() error {
+	dyn.terminationErr = dyn.sup.Terminate()
+	dyn.terminated = true
+	return dyn.terminationErr
+}
+
+// Wait blocks the execution of the current goroutine until the Supervisor
+// finishes it execution.
+func (dyn DynSupervisor) Wait() error {
+	return dyn.sup.Wait()
+}
+
+// GetName returns the name of the Spec used to start this Supervisor
+func (dyn DynSupervisor) GetName() string {
+	return dyn.sup.GetName()
+}
+
+// NewDynSupervisor creates a DynamicSupervisor which can start workers at
+// runtime in a procedural manner. It receives a context and the supervisor name
+// (for tracing purposes).
+//
+//
+// When to use a DynSupervisor?
+//
+// If you want to run supervised worker routines on dynamic inputs. This is
+// something that a regular Supervisor cannot do, as it needs to know the
+// children nodes at construction time.
+//
+// Differences to Supervisor
+//
+// As opposed to a Supervisor, a DynSupervisor:
+//
+// * Cannot receive node specifications to start then in an static fashion
+//
+// * It is able to spawn workers dynamically
+//
+// * In case of a hard crash and following restart, it will start with an empty
+//   list of children
+//
+func NewDynSupervisor(ctx context.Context, name string, opts ...Opt) (DynSupervisor, error) {
+	spec := NewSupervisorSpec(name, withNodes([]Node{}), opts...)
+	sup, err := spec.Start(ctx)
+	if err != nil {
+		return DynSupervisor{}, err
+	}
+	return DynSupervisor{sup: sup}, nil
+}

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -248,7 +248,8 @@ func (dyn *DynSupervisor) Spawn(nodeFn Node) (func() error, error) {
 			panic("did not get valid response value from control message. Implementation error")
 		}
 	case <-time.After(1 * time.Second):
-		// Not sure when this scenario would happen to be honest :shrug:
+		// Paranoid timeout. Better to not hang if this ever happens; to be honest,
+		// not sure when this is the case :shrug:
 		return nil, errors.New("could not get a creation confirmation from worker")
 	}
 }

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -9,13 +9,87 @@ import (
 	"github.com/capatazlib/go-capataz/internal/c"
 )
 
+// ctrlMsg executes some control logic on the Supervisor goroutine
+type ctrlMsg interface {
+	// processMsg receives all the required supervisor state to fullfill
+	// its purpose
+	processMsg(
+		evNotifier EventNotifier,
+		spec SupervisorSpec,
+		specChildren []c.ChildSpec,
+		supRuntimeName string,
+		supChildren map[string]c.Child,
+		supNotifyCh chan c.ChildNotification,
+	) ([]c.ChildSpec, map[string]c.Child)
+}
+
+type startChildResult struct {
+	childName string
+	startErr  startError
+}
+
 // startChildMsg is a message sent from clients to tell a supervisor to spawn
 // on-demand a worker routine.
 type startChildMsg struct {
 	node Node
 	// result could either be a startError or a string with the runtime name
-	resultChan chan<- interface{}
+	resultChan chan<- startChildResult
 }
+
+func (scm startChildMsg) processMsg(
+	evNotifier EventNotifier,
+	spec SupervisorSpec,
+	specChildren []c.ChildSpec,
+	supRuntimeName string,
+	supChildren map[string]c.Child,
+	supNotifyCh chan c.ChildNotification,
+) ([]c.ChildSpec, map[string]c.Child) {
+	// REMEMBER: WE ARE RUNNING THIS CODE IN THE SUPERVISOR THREAD
+
+	childSpec := scm.node(spec)
+
+	ch, startErr := startChildNode(spec, supRuntimeName, supNotifyCh, childSpec)
+	if startErr != nil {
+		// When we fail, we send an error to the supNotifyCh and return the error,
+		// this doesn't have any detrimental consequence in static supervisors,
+		// but on dynamic supervisors, it means the monitor loop will get bothered
+		// with an error that it should not really handle. We are going to read it
+		// out and return after that.
+		_ = <-supNotifyCh
+		// do not block waiting for a read
+		select {
+		case scm.resultChan <- startChildResult{
+			childName: "",
+			startErr:  startErr,
+		}:
+		default:
+		}
+
+		return specChildren, supChildren
+
+	}
+
+	// We store the child to the spec list because we need to terminate them
+	// when the supervisor is terminated in the correct order. This won't have
+	// unintended side-effects because a DynSupervisor once terminated, cannot
+	// be started again.
+	specChildren = append(specChildren, childSpec)
+	supChildren[ch.GetName()] = ch
+
+	select {
+	case scm.resultChan <- startChildResult{
+		childName: ch.GetName(),
+		startErr:  nil,
+	}:
+	// We return the regular name (not the runtime one), given that we store that
+	// in the childrenMap of the supervisor
+	default:
+	}
+
+	return specChildren, supChildren
+}
+
+var _ ctrlMsg = startChildMsg{}
 
 // terminateChildMsg is a message sent from clients to tell a supervisor to close a
 // previously spawned worker routine.
@@ -24,20 +98,51 @@ type terminateChildMsg struct {
 	resultChan chan<- terminateError
 }
 
-// ctlrMsgTag tells us which control message we need to cast/handle
-type ctrlMsgTag uint32
+func (tcm terminateChildMsg) processMsg(
+	evNotifier EventNotifier,
+	spec SupervisorSpec,
+	specChildren []c.ChildSpec,
+	supRuntimeName string,
+	supChildren map[string]c.Child,
+	supNotifyCh chan c.ChildNotification,
+) ([]c.ChildSpec, map[string]c.Child) {
+	// REMEMBER: WE ARE RUNNING THIS CODE IN THE SUPERVISOR THREAD
 
-const (
-	startChild ctrlMsgTag = iota
-	terminateChild
-)
+	ch, ok := supChildren[tcm.nodeName]
+	if !ok {
+		errMsg := fmt.Sprintf("worker %s not found", tcm.nodeName)
+		// do not block waiting for a read
+		select {
+		case tcm.resultChan <- errors.New(errMsg):
+		default:
+		}
 
-// ctlrMsg is a message sent from clients to a supervisor via a public API
-// method
-type ctrlMsg struct {
-	tag ctrlMsgTag
-	msg interface{}
+		return specChildren, supChildren
+	}
+
+	// we call our basic terminateChildNode function that is found in the
+	// monitor.go file
+	terminateErr := terminateChildNode(evNotifier, ch)
+
+	// do not block waiting for a read
+	select {
+	case tcm.resultChan <- terminateErr:
+	default:
+	}
+
+	// we remove the terminated child from the spec and the runtime children to
+	// avoid shutting it down on supervisor termination
+	for i, chSpec := range specChildren {
+		if chSpec.GetName() == ch.GetName() {
+			specChildren = append(specChildren[:i], specChildren[i+1:]...)
+			delete(supChildren, ch.GetName())
+		}
+	}
+
+	return specChildren, supChildren
 }
+
+var _ ctrlMsg = terminateChildMsg{}
 
 // DynSupervisor is a supervisor that can spawn workers in a procedural way.
 type DynSupervisor struct {
@@ -50,99 +155,30 @@ type DynSupervisor struct {
 // API calls like Spawn or Cancel a child node.
 func handleCtrlMsg(
 	eventNotifier EventNotifier,
-	supSpec SupervisorSpec,
-	supChildrenSpec []c.ChildSpec,
+	spec SupervisorSpec,
+	specChildren []c.ChildSpec,
 	supRuntimeName string,
 	supChildren map[string]c.Child,
 	supNotifyCh chan c.ChildNotification,
 	msg ctrlMsg,
 ) ([]c.ChildSpec, map[string]c.Child) {
-	switch msg.tag {
-	case startChild:
-		startcm, ok := msg.msg.(startChildMsg)
-		if !ok {
-			panic("Expected startChildMsg; got something else. Invalid Supervisor implementation")
-		}
-		childSpec := startcm.node(supSpec)
-
-		ch, startErr := startChildNode(supSpec, supRuntimeName, supNotifyCh, childSpec)
-		if startErr != nil {
-			// When we fail, we send an error to the supNotifyCh and return the error,
-			// this doesn't have any detrimental consequence in static supervisors,
-			// but on dynamic supervisors, it means the monitor loop will get bothered
-			// with an error that it should not really handle. We are going to read it
-			// out and return after that.
-			_ = <-supNotifyCh
-			// do not block waiting for a read
-			select {
-			case startcm.resultChan <- startErr:
-			default:
-			}
-
-			return supChildrenSpec, supChildren
-		}
-
-		// We store the child to the spec list because we need to terminate them
-		// when the supervisor is terminated in the correct order. This won't have
-		// unintended side-effects because a DynSupervisor once terminated, cannot
-		// be started again.
-		supChildrenSpec = append(supChildrenSpec, childSpec)
-		supChildren[ch.GetName()] = ch
-
-		select {
-		case startcm.resultChan <- ch.GetName():
-			// We return the regular name (not the runtime one), given that we store that
-			// in the childrenMap of the supervisor
-		default:
-		}
-
-		return supChildrenSpec, supChildren
-
-	case terminateChild:
-		terminatecm, ok := msg.msg.(terminateChildMsg)
-		ch, ok := supChildren[terminatecm.nodeName]
-		if !ok {
-			errMsg := fmt.Sprintf("worker %s not found", terminatecm.nodeName)
-			// do not block waiting for a read
-			select {
-			case terminatecm.resultChan <- errors.New(errMsg):
-			default:
-			}
-
-			return supChildrenSpec, supChildren
-		}
-
-		// we call our basic terminateChildNode function that is found in the
-		// monitor.go file
-		terminateErr := terminateChildNode(eventNotifier, ch)
-		// do not block waiting for a read
-		select {
-		case terminatecm.resultChan <- terminateErr:
-		default:
-		}
-
-		// we remove the terminated child from the spec and the runtime children to
-		// avoid shutting it down on supervisor termination
-		for i, chSpec := range supChildrenSpec {
-			if chSpec.GetName() == ch.GetName() {
-				supChildrenSpec = append(supChildrenSpec[:i], supChildrenSpec[i+1:]...)
-				delete(supChildren, ch.GetName())
-			}
-		}
-
-		return supChildrenSpec, supChildren
-
-	default:
-		panic("Unknown control message received. Invalid Supervisor implementation.")
-	}
+	return msg.processMsg(
+		eventNotifier,
+		spec,
+		specChildren,
+		supRuntimeName,
+		supChildren,
+		supNotifyCh,
+	)
 }
 
 func (dyn *DynSupervisor) terminateNode(nodeName string) func() error {
+	// REMEMBER: WE ARE RUNNING ON THE CLIENT API THREAD
 
 	// we initialize the resultCh with a buffer of 1, we may store the result
 	// before the client is ready to read it.
 	resultCh := make(chan terminateError, 1)
-	terminatemsg := terminateChildMsg{
+	msg := terminateChildMsg{
 		nodeName:   nodeName,
 		resultChan: resultCh,
 	}
@@ -163,10 +199,6 @@ func (dyn *DynSupervisor) terminateNode(nodeName string) func() error {
 		}()
 		// block until the supervisor can handle the request, in case the
 		// supervisor is stopped, this line is going to panic
-		msg := ctrlMsg{
-			tag: terminateChild,
-			msg: terminatemsg,
-		}
 		select {
 		case dyn.sup.ctrlCh <- msg:
 		case _ = <-time.After(1 * time.Second):
@@ -192,6 +224,8 @@ func (dyn *DynSupervisor) terminateNode(nodeName string) func() error {
 // start of this worker failed. This function blocks until the worker is
 // started.
 func (dyn *DynSupervisor) Spawn(nodeFn Node) (func() error, error) {
+	// REMEMBER: WE ARE RUNNING ON THE CLIENT API THREAD
+
 	// if we already registered a terminationErr, return it
 	if dyn.terminated {
 		return nil, fmt.Errorf("supervisor already terminated: %w", dyn.terminationErr)
@@ -206,17 +240,10 @@ func (dyn *DynSupervisor) Spawn(nodeFn Node) (func() error, error) {
 
 	// we initialize the resultCh with a buffer of 1, we may store the result
 	// before the client is ready to read it.
-	resultCh := make(chan interface{}, 1)
-	startmsg := startChildMsg{
+	resultCh := make(chan startChildResult, 1)
+	msg := startChildMsg{
 		node:       nodeFn,
 		resultChan: resultCh,
-	}
-
-	// block until the supervisor can handle the request, in case the
-	// supervisor is stopped, this line is going to panic
-	msg := ctrlMsg{
-		tag: startChild,
-		msg: startmsg,
 	}
 
 	select {
@@ -234,19 +261,10 @@ func (dyn *DynSupervisor) Spawn(nodeFn Node) (func() error, error) {
 			panic("could not get the result of a spawn call. Implementation error")
 		}
 
-		switch v := result.(type) {
-		// successful case
-		case string:
-			return dyn.terminateNode(v), nil
-
-			// error case
-		case error:
-			return nil, v
-
-			// unknown case
-		default:
-			panic("did not get valid response value from control message. Implementation error")
+		if result.startErr != nil {
+			return nil, result.startErr
 		}
+		return dyn.terminateNode(result.childName), nil
 	case <-time.After(1 * time.Second):
 		// Paranoid timeout. Better to not hang if this ever happens; to be honest,
 		// not sure when this is the case :shrug:

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -188,14 +188,14 @@ func (dyn *DynSupervisor) terminateNode(nodeName string) func() error {
 			if panicVal == nil {
 				return
 			}
-			switch v := panicVal.(type) {
-			case error:
-				err = fmt.Errorf("could not talk to supervisor: %w", v)
+
+			if panicErr, ok := panicVal.(error); ok {
+				err = fmt.Errorf("could not talk to supervisor: %w", panicErr)
 				return
-			default:
-				// retrigger panic, this would happen on an implementation error
-				panic(panicVal)
 			}
+
+			// retrigger panic, this would happen on an implementation error
+			panic(panicVal)
 		}()
 		// block until the supervisor can handle the request, in case the
 		// supervisor is stopped, this line is going to panic

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -284,7 +284,7 @@ func (dyn DynSupervisor) GetName() string {
 //
 // As opposed to a Supervisor, a DynSupervisor:
 //
-// * Cannot receive node specifications to start then in an static fashion
+// * Cannot receive node specifications to start them in an static fashion
 //
 // * It is able to spawn workers dynamically
 //

--- a/cap/dyn_supervisor_test.go
+++ b/cap/dyn_supervisor_test.go
@@ -356,17 +356,17 @@ func TestDynCancelAlreadyTerminatedWorker(t *testing.T) {
 	)
 }
 
-// func TestDynCancelAlreadyTerminatedSupervisor(t *testing.T) {
-//	sup, err := cap.NewDynSupervisor(context.TODO(), "root")
-//	assert.NoError(t, err)
+func TestDynCancelAlreadyTerminatedSupervisor(t *testing.T) {
+	sup, err := cap.NewDynSupervisor(context.TODO(), "root")
+	assert.NoError(t, err)
 
-//	cancelWorker, err := sup.Spawn(WaitDoneWorker("one"))
-//	assert.NoError(t, err)
+	cancelWorker, err := sup.Spawn(WaitDoneWorker("one"))
+	assert.NoError(t, err)
 
-//	err = sup.Terminate()
-//	assert.NoError(t, err)
+	err = sup.Terminate()
+	assert.NoError(t, err)
 
-//	err = cancelWorker()
-//	assert.Error(t, err)
-//	assert.Equal(t, "could not talk to supervisor: send on closed channel", err.Error())
-// }
+	err = cancelWorker()
+	assert.Error(t, err)
+	assert.Equal(t, "could not talk to supervisor: send on closed channel", err.Error())
+}

--- a/cap/dyn_supervisor_test.go
+++ b/cap/dyn_supervisor_test.go
@@ -1,0 +1,264 @@
+package cap_test
+
+//
+// NOTE: If you feel it is counter-intuitive to have workers start before
+// supervisors in the assertions bellow, check stest/README.md
+//
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/cap"
+	. "github.com/capatazlib/go-capataz/internal/stest"
+)
+
+func TestDynStartSingleChild(t *testing.T) {
+	events, errs := ObserveDynSupervisor(
+		context.TODO(),
+		"root",
+		[]cap.Node{WaitDoneWorker("one")},
+		// []cap.Node{},
+		[]cap.Opt{},
+		func(cap.DynSupervisor, EventManager) {},
+	)
+	assert.Empty(t, errs)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			SupervisorStarted("root"),
+			WorkerStarted("root/one"),
+			WorkerTerminated("root/one"),
+			SupervisorTerminated("root"),
+		})
+}
+
+// Test a supervision tree with three children start and stop in the default
+// order (LeftToRight)
+func TestDynStartMutlipleChildrenLeftToRight(t *testing.T) {
+	events, errs := ObserveDynSupervisor(
+		context.TODO(),
+		"root",
+		[]cap.Node{
+			WaitDoneWorker("child0"),
+			WaitDoneWorker("child1"),
+			WaitDoneWorker("child2"),
+		},
+		[]cap.Opt{},
+		func(cap.DynSupervisor, EventManager) {},
+	)
+
+	assert.Empty(t, errs)
+	t.Run("starts and stops routines in the correct order", func(t *testing.T) {
+		AssertExactMatch(t, events,
+			[]EventP{
+				SupervisorStarted("root"),
+				WorkerStarted("root/child0"),
+				WorkerStarted("root/child1"),
+				WorkerStarted("root/child2"),
+				WorkerTerminated("root/child2"),
+				WorkerTerminated("root/child1"),
+				WorkerTerminated("root/child0"),
+				SupervisorTerminated("root"),
+			})
+	})
+}
+
+// Test a supervision tree with three children start and stop in the default
+// order (LeftToRight)
+func TestDynStartMutlipleChildrenRightToLeft(t *testing.T) {
+	events, errs := ObserveDynSupervisor(
+		context.TODO(),
+		"root",
+		[]cap.Node{
+			WaitDoneWorker("child0"),
+			WaitDoneWorker("child1"),
+			WaitDoneWorker("child2"),
+		},
+		[]cap.Opt{
+			cap.WithOrder(cap.RightToLeft),
+		},
+		func(cap.DynSupervisor, EventManager) {},
+	)
+
+	assert.Empty(t, errs)
+
+	t.Run("starts and stops routines in the correct order", func(t *testing.T) {
+		AssertExactMatch(t, events,
+			[]EventP{
+				SupervisorStarted("root"),
+				WorkerStarted("root/child0"),
+				WorkerStarted("root/child1"),
+				WorkerStarted("root/child2"),
+				WorkerTerminated("root/child0"),
+				WorkerTerminated("root/child1"),
+				WorkerTerminated("root/child2"),
+				SupervisorTerminated("root"),
+			})
+	})
+}
+
+func TestDynStartFailedChild(t *testing.T) {
+	parentName := "root"
+	b0n := "branch0"
+	b1n := "branch1"
+
+	cs := []cap.Node{
+		WaitDoneWorker("child0"),
+		WaitDoneWorker("child1"),
+		WaitDoneWorker("child2"),
+		// NOTE: FailStartWorker here
+		FailStartWorker("child3"),
+		WaitDoneWorker("child4"),
+	}
+
+	b0 := cap.NewSupervisorSpec(b0n, cap.WithNodes(cs[0], cs[1]))
+	b1 := cap.NewSupervisorSpec(b1n, cap.WithNodes(cs[2], cs[3], cs[4]))
+
+	events, errs := ObserveDynSupervisor(
+		context.TODO(),
+		parentName,
+		[]cap.Node{
+			cap.Subtree(b0),
+			cap.Subtree(b1),
+		},
+		[]cap.Opt{},
+		func(cap.DynSupervisor, EventManager) {},
+	)
+
+	assert.NotEmpty(t, errs)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			SupervisorStarted("root"),
+			// start children from left to right
+			WorkerStarted("root/branch0/child0"),
+			WorkerStarted("root/branch0/child1"),
+			SupervisorStarted("root/branch0"),
+			WorkerStarted("root/branch1/child2"),
+			//
+			// Note child3 fails at this point
+			//
+			WorkerStartFailed("root/branch1/child3"),
+			//
+			// After a failure a few things will happen:
+			//
+			// * The `child4` worker initialization is skipped because of an error on
+			// previous sibling
+			//
+			// * Previous sibling children get stopped in reversed order
+			//
+			// * The start function returns an error
+			//
+			WorkerTerminated("root/branch1/child2"),
+			SupervisorStartFailed("root/branch1"),
+			WorkerTerminated("root/branch0/child1"),
+			WorkerTerminated("root/branch0/child0"),
+			SupervisorTerminated("root/branch0"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestDynTerminateFailedChild(t *testing.T) {
+	parentName := "root"
+	b0n := "branch0"
+	b1n := "branch1"
+
+	cs := []cap.Node{
+		WaitDoneWorker("child0"),
+		WaitDoneWorker("child1"),
+		// NOTE: There is a NeverTerminateWorker here
+		NeverTerminateWorker("child2"),
+		WaitDoneWorker("child3"),
+	}
+
+	b0 := cap.NewSupervisorSpec(b0n, cap.WithNodes(cs[0], cs[1]))
+	b1 := cap.NewSupervisorSpec(b1n, cap.WithNodes(cs[2], cs[3]))
+
+	events, errs := ObserveDynSupervisor(
+		context.TODO(),
+		parentName,
+		[]cap.Node{
+			cap.Subtree(b0),
+			cap.Subtree(b1),
+		},
+		[]cap.Opt{},
+		func(cap.DynSupervisor, EventManager) {},
+	)
+
+	assert.NotEmpty(t, errs)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			SupervisorStarted("root"),
+			// start children from left to right
+			WorkerStarted("root/branch0/child0"),
+			WorkerStarted("root/branch0/child1"),
+			SupervisorStarted("root/branch0"),
+			WorkerStarted("root/branch1/child2"),
+			WorkerStarted("root/branch1/child3"),
+			SupervisorStarted("root/branch1"),
+			// NOTE: From here, the stop of the supervisor begins
+			WorkerTerminated("root/branch1/child3"),
+			// NOTE: the child2 never stops and fails with a timeout
+			WorkerFailed("root/branch1/child2"),
+			// NOTE: The supervisor branch1 fails because of child2 timeout
+			SupervisorFailed("root/branch1"),
+			WorkerTerminated("root/branch0/child1"),
+			WorkerTerminated("root/branch0/child0"),
+			SupervisorTerminated("root/branch0"),
+			SupervisorFailed("root"),
+		},
+	)
+}
+
+func TestDynSpawnAfterTerminate(t *testing.T) {
+	sup, err := cap.NewDynSupervisor(context.TODO(), "root")
+	assert.NoError(t, err)
+
+	sup.Terminate()
+	_, err = sup.Spawn(WaitDoneWorker("one"))
+
+	assert.Error(t, err)
+}
+
+func TestDynSpawnAfterCrashedSupervisor(t *testing.T) {
+	failingNode, failWorker := FailOnSignalWorker(
+		1, "failing", cap.WithTolerance(0, 1*time.Millisecond),
+	)
+
+	events, errs := ObserveDynSupervisor(
+		context.TODO(),
+		"root",
+		[]cap.Node{},
+		[]cap.Opt{},
+		func(sup cap.DynSupervisor, em EventManager) {
+			_, err := sup.Spawn(failingNode)
+			assert.NoError(t, err)
+
+			failWorker(false)
+
+			evIt := em.Iterator()
+			evIt.SkipTill(WorkerFailed("root/failing"))
+
+			_, err = sup.Spawn(failingNode)
+			assert.Error(t, err)
+		},
+	)
+
+	assert.Empty(t, errs)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			SupervisorStarted("root"),
+			// start children from left to right
+			WorkerStarted("root/failing"),
+			WorkerFailed("root/failing"),
+			SupervisorFailed("root"),
+		},
+	)
+}

--- a/cap/dyn_supervisor_test.go
+++ b/cap/dyn_supervisor_test.go
@@ -159,6 +159,8 @@ func TestDynStartFailedChild(t *testing.T) {
 			WorkerTerminated("root/branch0/child0"),
 			SupervisorTerminated("root/branch0"),
 			SupervisorTerminated("root"),
+			// ^ here, we get a supervisor terminated because the supervisor does not
+			// crash on children start, as opposed to static supervisors
 		},
 	)
 }

--- a/cap/dyn_supervisor_test.go
+++ b/cap/dyn_supervisor_test.go
@@ -356,17 +356,17 @@ func TestDynCancelAlreadyTerminatedWorker(t *testing.T) {
 	)
 }
 
-func TestDynCancelAlreadyTerminatedSupervisor(t *testing.T) {
-	sup, err := cap.NewDynSupervisor(context.TODO(), "root")
-	assert.NoError(t, err)
+// func TestDynCancelAlreadyTerminatedSupervisor(t *testing.T) {
+//	sup, err := cap.NewDynSupervisor(context.TODO(), "root")
+//	assert.NoError(t, err)
 
-	cancelWorker, err := sup.Spawn(WaitDoneWorker("one"))
-	assert.NoError(t, err)
+//	cancelWorker, err := sup.Spawn(WaitDoneWorker("one"))
+//	assert.NoError(t, err)
 
-	err = sup.Terminate()
-	assert.NoError(t, err)
+//	err = sup.Terminate()
+//	assert.NoError(t, err)
 
-	err = cancelWorker()
-	assert.Error(t, err)
-	assert.Equal(t, "could not talk to supervisor: send on closed channel", err.Error())
-}
+//	err = cancelWorker()
+//	assert.Error(t, err)
+//	assert.Equal(t, "could not talk to supervisor: send on closed channel", err.Error())
+// }

--- a/cap/monitor.go
+++ b/cap/monitor.go
@@ -336,9 +336,6 @@ func runMonitorLoop(
 		// in case we run in the async strategy we notify the spawner that we
 		// started with an error
 		onStart(restartErr)
-		// We signal that we terminated, the error is not reported here because
-		// it was reported in the onStart callback
-		onTerminate(nil)
 		return restartErr
 	}
 

--- a/cap/monitor.go
+++ b/cap/monitor.go
@@ -172,7 +172,7 @@ func startChildNodes(
 		if chStartErr != nil {
 			nodeErrMap := terminateChildNodes(spec, supChildrenSpecs, children)
 			// Is important we stop the children before we finish the supervisor
-			return nil, &SupervisorTerminationError{
+			return nil, &SupervisorError{
 				supRuntimeName: supRuntimeName,
 				nodeErr:        chStartErr,
 				nodeErrMap:     nodeErrMap,
@@ -249,7 +249,7 @@ func terminateSupervisor(
 	onTerminate func(error),
 	restartErr *c.ErrorToleranceReached,
 ) error {
-	var terminateErr *SupervisorTerminationError
+	var terminateErr *SupervisorError
 	supNodeErrMap := terminateChildNodes(supSpec, supChildrenSpecs, supChildren)
 	supRscCleanupErr := supRscCleanup()
 
@@ -259,7 +259,7 @@ func terminateSupervisor(
 
 		// On async strategy, we notify that the spawner terminated with an
 		// error
-		terminateErr = &SupervisorTerminationError{
+		terminateErr = &SupervisorError{
 			supRuntimeName: supRuntimeName,
 			nodeErrMap:     supNodeErrMap,
 			rscCleanupErr:  supRscCleanupErr,

--- a/cap/monitor.go
+++ b/cap/monitor.go
@@ -194,7 +194,6 @@ func terminateChildNode(
 	terminationErr := ch.Terminate()
 
 	if terminationErr != nil {
-
 		// we also notify that the process failed
 		eventNotifier.processFailed(chSpec.GetTag(), ch.GetRuntimeName(), terminationErr)
 		return terminationErr

--- a/cap/root.go
+++ b/cap/root.go
@@ -82,11 +82,8 @@ func (spec SupervisorSpec) rootStart(
 		return Supervisor{}, rscAllocError
 	}
 
-	// The variables bellow are used to detect the termination of a supervisor.
-	// This is necessary because when we run a DynSupervisor, we need to make sure
-	// that we *do not* spawn workers on a terminated supervisor, otherwise we run
-	// the risk of getting a panic error, not good.
 	tm := newTerminationManager()
+	// ^^^ used to detect the termination of a supervisor.
 
 	sup := Supervisor{
 		runtimeName: supRuntimeName,

--- a/cap/root.go
+++ b/cap/root.go
@@ -86,7 +86,7 @@ func (spec SupervisorSpec) rootStart(
 	// The variables bellow are used to detect the termination of a supervisor.
 	// This is necessary because when we run a DynSupervisor, we need to make sure
 	// that we *do not* spawn workers on a terminated supervisor, otherwise we run
-	// the risk to get a panic error, not good.
+	// the risk of getting a panic error, not good.
 	var mux sync.Mutex
 
 	var terminatedVal = false

--- a/cap/spec.go
+++ b/cap/spec.go
@@ -213,7 +213,7 @@ func (spec SupervisorSpec) buildChildrenSpecs() ([]c.ChildSpec, CleanupResources
 // 2) Resource cleanup returns an error
 //
 // In this scenario, the termination procedure will collect the error and report
-// it in the returned SupervisorTerminationError.
+// it in the returned SupervisorError.
 //
 // 3) Resource allocation/cleanup hangs
 //

--- a/cap/subtree.go
+++ b/cap/subtree.go
@@ -37,7 +37,7 @@ func (spec SupervisorSpec) run(
 	notifyCh := make(chan c.ChildNotification)
 
 	// ctrlCh is used to keep track of request from client APIs (e.g. spawn child)
-	// ctrlCh := make(chan ControlMsg)
+	ctrlCh := make(chan ctrlMsg)
 
 	supRuntimeName := buildRuntimeName(spec, parentName)
 
@@ -52,7 +52,7 @@ func (spec SupervisorSpec) run(
 		supRuntimeName,
 		supRscCleanup,
 		notifyCh,
-		// ctrlCh,
+		ctrlCh,
 		startTime,
 		onStart,
 		onTerminate,

--- a/cap/supervisor.go
+++ b/cap/supervisor.go
@@ -13,6 +13,10 @@ import (
 // terminationManager offers an API to do thread-safe tracking of the
 // termination state of a Supervisor. This record is designed to hide the
 // required internal mutability on the Supervisor record.
+//
+// This is a necessary type; when we run a DynSupervisor, we need to make sure
+// that we *do not* spawn workers on a terminated supervisor, otherwise we run
+// the risk of getting a panic error.
 type terminationManager struct {
 	mux          *sync.Mutex
 	terminated   bool

--- a/cap/supervisor.go
+++ b/cap/supervisor.go
@@ -149,9 +149,9 @@ func getCrashError(
 	}
 }
 
-// GetCrashError returns a crash error if there is one, the second parameter
+// GetCrashError returns a crash error if there is one, the first parameter
 // indicates if the supervisor is running or not. If the returned error is not
-// nil, the second result will always be true.
+// nil, the first result will always be true.
 func (sup Supervisor) GetCrashError(block bool) (bool, error) {
 	return getCrashError(
 		sup.spec.eventNotifier,

--- a/cap/supervisor.go
+++ b/cap/supervisor.go
@@ -4,6 +4,7 @@ package cap
 // Supervisor API
 
 import (
+	"sync"
 	"time"
 
 	"github.com/capatazlib/go-capataz/internal/c"
@@ -15,14 +16,18 @@ import (
 // supervisor detects an error has occured. A Supervisor will always be
 // generated from a SupervisorSpec
 type Supervisor struct {
-	runtimeName    string
-	ctrlCh         chan ctrlMsg
-	terminateCh    chan error
-	terminationErr error
-	spec           SupervisorSpec
-	children       map[string]c.Child
-	cancel         func()
-	wait           func(time.Time, startError) error
+	runtimeName string
+	ctrlCh      chan ctrlMsg
+
+	mux          *sync.Mutex
+	terminateCh  chan error
+	terminated   *bool
+	terminateErr *error
+
+	spec     SupervisorSpec
+	children map[string]c.Child
+	cancel   func()
+	wait     func(time.Time, startError) error
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,16 +55,112 @@ func (sup Supervisor) GetName() string {
 	return sup.spec.GetName()
 }
 
+// getTerminateErr is an utility function that allows us to query if the
+// Supervisor was terminated in a concurrent-safe manner. If error is not nil,
+// then first bool must be true
+func getTerminateErr(
+	mux *sync.Mutex,
+	terminated *bool,
+	terminateErr *error,
+) (bool, error) {
+	mux.Lock()
+	defer mux.Unlock()
+	// We already did the termination, just return the result
+	if terminated != nil {
+		return *terminated, *terminateErr
+	}
+	return false, nil
+}
+
+// storeTerminationError is responsible of registering the final state of the supervisor
+func storeTerminationErr(
+	eventNotifier EventNotifier,
+	supRuntimeName string,
+	mux *sync.Mutex,
+	terminated *bool,
+	terminateErr *error,
+	err error,
+	stopingTime time.Time,
+) {
+	mux.Lock()
+	defer mux.Unlock()
+	*terminated = true
+	*terminateErr = err
+	if err != nil {
+		eventNotifier.supervisorFailed(supRuntimeName, err)
+		return
+	}
+
+	// stopingTime is only relevant when we call the internal wait function
+	// from the Terminate() public API; if we just called from Wait(), we don't
+	// need to keep track of the stop duration
+	if stopingTime == (time.Time{}) {
+		stopingTime = time.Now()
+	}
+	eventNotifier.supervisorTerminated(supRuntimeName, stopingTime)
+}
+
 // GetCrashError will return an error if the supervisor crashed, otherwise
 // returns nil.
-func (sup Supervisor) GetCrashError() error {
-	var terminationErr error
+func getCrashError(
+	eventNotifier EventNotifier,
+	supRuntimeName string,
+	mux *sync.Mutex,
+	terminateCh chan error,
+	terminated *bool,
+	terminateErr *error,
+	stopingTime time.Time,
+	block bool,
+) (bool, error) {
+
+	if terminatedVal, terminateErrVal := getTerminateErr(mux, terminated, terminateErr); terminatedVal {
+		return terminatedVal, terminateErrVal
+	}
+
+	if block {
+		terminateErrVal := <-terminateCh
+		storeTerminationErr(
+			eventNotifier,
+			supRuntimeName,
+			mux,
+			terminated,
+			terminateErr,
+			terminateErrVal,
+			stopingTime,
+		)
+		return true, terminateErrVal
+	}
+
 	select {
-	case terminationErr = <-sup.terminateCh:
+	case terminateErrVal := <-terminateCh:
+		storeTerminationErr(
+			eventNotifier,
+			supRuntimeName,
+			mux,
+			terminated,
+			terminateErr,
+			terminateErrVal,
+			time.Time{},
+		)
+		return true, terminateErrVal
+
 	default:
+		return false, nil
 	}
-	if terminationErr != nil {
-		sup.spec.eventNotifier.supervisorFailed(sup.runtimeName, terminationErr)
-	}
-	return terminationErr
+}
+
+// GetCrashError returns a crash error if there is one, the second parameter
+// indicates if the supervisor is running or not. If the returned error is not
+// nil, the second result will always be true.
+func (sup Supervisor) GetCrashError(block bool) (bool, error) {
+	return getCrashError(
+		sup.spec.eventNotifier,
+		sup.runtimeName,
+		sup.mux,
+		sup.terminateCh,
+		sup.terminated,
+		sup.terminateErr,
+		time.Time{},
+		false, /* block */
+	)
 }

--- a/cap/supervisor_options.go
+++ b/cap/supervisor_options.go
@@ -3,6 +3,7 @@ package cap
 // Opt is a type used to configure a SupervisorSpec
 type Opt func(*SupervisorSpec)
 
+// TODO: Change name to WithStartOrder
 // WithOrder is an Opt that specifies the start/stop order of a supervisor's
 // children nodes
 //

--- a/cap/supervisor_options.go
+++ b/cap/supervisor_options.go
@@ -52,19 +52,14 @@ func WithNotifier(en EventNotifier) Opt {
 	}
 }
 
-// withNodes is used internally by a few functions in this API.
-func withNodes(nodes []Node) BuildNodesFn {
-	emptyCleanupResources := func() error { return nil }
-	return func() ([]Node, CleanupResourcesFn, error) {
-		return nodes, emptyCleanupResources, nil
-	}
-}
-
 // WithNodes allows the registration of child nodes in a SupervisorSpec. Node
 // records passed to this function are going to be supervised by the Supervisor
 // created from a SupervisorSpec.
 //
 // Check the documentation of NewSupervisorSpec for more details and examples.
 func WithNodes(nodes ...Node) BuildNodesFn {
-	return withNodes(nodes)
+	emptyCleanupResources := func() error { return nil }
+	return func() ([]Node, CleanupResourcesFn, error) {
+		return nodes, emptyCleanupResources, nil
+	}
 }

--- a/cap/supervisor_options.go
+++ b/cap/supervisor_options.go
@@ -3,7 +3,6 @@ package cap
 // Opt is a type used to configure a SupervisorSpec
 type Opt func(*SupervisorSpec)
 
-// TODO: Change name to WithStartOrder
 // WithOrder is an Opt that specifies the start/stop order of a supervisor's
 // children nodes
 //
@@ -15,6 +14,7 @@ type Opt func(*SupervisorSpec)
 // * RightToLeft -- Start children nodes from right to left, stop them from left
 // to right
 //
+// TODO: Change name to WithStartOrder
 func WithOrder(o Order) Opt {
 	return func(spec *SupervisorSpec) {
 		spec.order = o

--- a/cap/supervisor_options.go
+++ b/cap/supervisor_options.go
@@ -52,14 +52,19 @@ func WithNotifier(en EventNotifier) Opt {
 	}
 }
 
+// withNodes is used internally by a few functions in this API.
+func withNodes(nodes []Node) BuildNodesFn {
+	emptyCleanupResources := func() error { return nil }
+	return func() ([]Node, CleanupResourcesFn, error) {
+		return nodes, emptyCleanupResources, nil
+	}
+}
+
 // WithNodes allows the registration of child nodes in a SupervisorSpec. Node
 // records passed to this function are going to be supervised by the Supervisor
 // created from a SupervisorSpec.
 //
 // Check the documentation of NewSupervisorSpec for more details and examples.
 func WithNodes(nodes ...Node) BuildNodesFn {
-	emptyCleanupResources := func() error { return nil }
-	return func() ([]Node, CleanupResourcesFn, error) {
-		return nodes, emptyCleanupResources, nil
-	}
+	return withNodes(nodes)
 }

--- a/cap/worker_options.go
+++ b/cap/worker_options.go
@@ -106,7 +106,7 @@ var WithCapturePanic = c.WithCapturePanic
 var WithTag = c.WithTag
 
 // WithTolerance is a WorkerOpt that specifies how many errors the supervisor
-// should be willing to tolerate before giving up restarting it and fail.
+// should be willing to tolerate before giving up restarting and fail.
 //
 // If the tolerance is met, the parent supervisor is going to fail, if this is a
 // sub-tree, this error is going to be handled by a grand-parent supervisor,

--- a/internal/c/new.go
+++ b/internal/c/new.go
@@ -2,6 +2,7 @@ package c
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -88,7 +89,7 @@ func NewWithNotifyStart(
 	spec.Name = name
 
 	if startFn == nil {
-		panic("Child cannot have empty start function")
+		panic(fmt.Sprintf("Child %s cannot have empty start function\n", name))
 	}
 
 	// apply options

--- a/internal/stest/assertions.go
+++ b/internal/stest/assertions.go
@@ -124,6 +124,11 @@ func AssertPartialMatch(t *testing.T, evs []cap.Event, preds []EventP) {
 	}
 }
 
+// ObserveDynSupervisor is an utility function that receives all the arguments
+// required to build a DynSupervisor, and a callback that when executed will
+// block until some point in the future (after we performed the side-effects we
+// are testing). This function returns the list of events that happened in the monitored
+// supervised tree, as well as any crash errors.
 func ObserveDynSupervisor(
 	ctx context.Context,
 	rootName string,
@@ -204,7 +209,8 @@ func ObserveDynSupervisor(
 // ObserveSupervisor is an utility function that receives all the arguments
 // required to build a SupervisorSpec, and a callback that when executed will
 // block until some point in the future (after we performed the side-effects we
-// are testing).
+// are testing). This function returns the list of events that happened in the
+// monitored supervised tree, as well as any crash errors.
 func ObserveSupervisor(
 	ctx context.Context,
 	rootName string,

--- a/internal/stest/assertions.go
+++ b/internal/stest/assertions.go
@@ -183,11 +183,6 @@ func ObserveDynSupervisor(
 	// be the last event reported
 	evIt.SkipTill(ProcessName(rootName))
 
-	if err != nil {
-		callback(sup, evManager)
-		return evManager.Snapshot(), []error{err}
-	}
-
 	// callback to do assertions with the event manager
 	callback(sup, evManager)
 

--- a/internal/stest/assertions.go
+++ b/internal/stest/assertions.go
@@ -157,7 +157,7 @@ func ObserveDynSupervisor(
 
 	errors := []error{}
 
-	// start procedurally the children given children
+	// start procedurally the given children
 	for _, node := range childNodes {
 		_, spawnErr := sup.Spawn(node)
 		if spawnErr != nil {

--- a/internal/stest/evmanager.go
+++ b/internal/stest/evmanager.go
@@ -104,6 +104,7 @@ func (ei *EventIterator) foldl(
 	return acc
 }
 
+// TODO: Change name to WaitTill
 // SkipTill blocks until an event from the supervision system returns true for
 // the given predicate
 func (ei *EventIterator) SkipTill(pred EventP) {

--- a/internal/stest/evmanager.go
+++ b/internal/stest/evmanager.go
@@ -104,9 +104,9 @@ func (ei *EventIterator) foldl(
 	return acc
 }
 
-// TODO: Change name to WaitTill
 // SkipTill blocks until an event from the supervision system returns true for
 // the given predicate
+// TODO: Change name to WaitTill
 func (ei *EventIterator) SkipTill(pred EventP) {
 	_ = ei.foldl(nil, func(_ interface{}, ev cap.Event) (bool, interface{}) {
 		if pred.Call(ev) {

--- a/internal/stest/evmanager.go
+++ b/internal/stest/evmanager.go
@@ -66,7 +66,7 @@ func (em EventManager) StartCollector(ctx context.Context) {
 // EventCollector is used as an event notifier of a supervision system
 func (em EventManager) EventCollector(ctx context.Context) func(ev cap.Event) {
 	return func(ev cap.Event) {
-		// NOTE: DO NOT REMOVE LINE BELLOW (debug tool)
+		// NOTE: DO NOT REMOVE LINE BELLOW (DEBUG tool)
 		// fmt.Printf("%+v\n", ev)
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Closes (#42)

### Problem

As a developer, I want to spawn supervised worker routines dynamically.

### Solution

This commit offers the DynSupervisor API, which allows us to create a child-less Supervisor that can monitor any worker routine that is spawned in a procedural fashion.

### Changes

* Add DynSupervisor type
* Add Supervisor.GetCrashError
* Add startChildNode function to simplify the startChildNodes function
* Add ObserveDynSupervisor to test dynamic supervisors