### PR TITLE
Deprecate WithOrder in favor of WithStartOrder

### DIFF
--- a/cap/doc.go
+++ b/cap/doc.go
@@ -94,7 +94,7 @@ You can create a SupervisorSpec using the NewSupervisorSpec function
 		// (2)
 		cap.WithNodes(myWorker, myOtherWorker, cap.Subtree(mySubsystem)),
 		// (3)
-		cap.WithOrder(cap.LeftToRight),
+		cap.WithStartOrder(cap.LeftToRight),
 		// (4)
 		cap.WithStrategy(cap.OneForOne),
 	)
@@ -259,7 +259,7 @@ call.
 				}, cleanupFn, nil
 			},
 			cap.WithStrategy(cap.OneForOne),
-			cap.WithOrder(cap.LeftToRight),
+			cap.WithStartOrder(cap.LeftToRight),
 		)
 
 	}

--- a/cap/dyn_supervisor_test.go
+++ b/cap/dyn_supervisor_test.go
@@ -86,7 +86,7 @@ func TestDynStartMutlipleChildrenRightToLeft(t *testing.T) {
 		},
 		[]cap.Opt{
 			// start order override happens here
-			cap.WithOrder(cap.RightToLeft),
+			cap.WithStartOrder(cap.RightToLeft),
 		},
 		func(cap.DynSupervisor, EventManager) {},
 	)

--- a/cap/monitor.go
+++ b/cap/monitor.go
@@ -149,7 +149,7 @@ func startChildNode(
 
 // startChildNodes iterates over all the children (specified with `cap.WithNodes`
 // and `cap.WithSubtree`) starting a goroutine for each. The children iteration
-// will be sorted as specified with the `cap.WithOrder` option. In case any child
+// will be sorted as specified with the `cap.WithStartOrder` option. In case any child
 // fails to start, the supervisor start operation will be aborted and all the
 // started children so far will be stopped in the reverse order.
 func startChildNodes(

--- a/cap/spec.go
+++ b/cap/spec.go
@@ -146,7 +146,7 @@ func (spec SupervisorSpec) buildChildrenSpecs() ([]c.ChildSpec, CleanupResources
 //       // (2)
 //       // Specify child nodes start from right to left (reversed order) and
 //       // stop from left to right.
-//       cap.WithOrder(cap.RightToLeft),
+//       cap.WithStartOrder(cap.RightToLeft),
 //     )
 //
 //
@@ -196,7 +196,7 @@ func (spec SupervisorSpec) buildChildrenSpecs() ([]c.ChildSpec, CleanupResources
 //       },
 //
 //       // (2)
-//       cap.WithOrder(cap.RightToLeft),
+//       cap.WithStartOrder(cap.RightToLeft),
 //     )
 //
 // Dealing with errors

--- a/cap/supervisor_options.go
+++ b/cap/supervisor_options.go
@@ -3,7 +3,7 @@ package cap
 // Opt is a type used to configure a SupervisorSpec
 type Opt func(*SupervisorSpec)
 
-// WithOrder is an Opt that specifies the start/stop order of a supervisor's
+// WithStartOrder is an Opt that specifies the start/stop order of a supervisor's
 // children nodes
 //
 // Possible values may be:
@@ -14,12 +14,16 @@ type Opt func(*SupervisorSpec)
 // * RightToLeft -- Start children nodes from right to left, stop them from left
 // to right
 //
-// TODO: Change name to WithStartOrder
-func WithOrder(o Order) Opt {
+func WithStartOrder(o Order) Opt {
 	return func(spec *SupervisorSpec) {
 		spec.order = o
 	}
 }
+
+// WithOrder is a backwards compatible alias to WithStartOrder
+//
+// Deprecated: Use WithStartOrder instead
+var WithOrder = WithStartOrder
 
 // WithStrategy is an Opt that specifies how children nodes of a supervisor get
 // restarted when one of the nodes fails

--- a/cap/supervisor_test.go
+++ b/cap/supervisor_test.go
@@ -77,7 +77,7 @@ func TestStartMutlipleChildrenRightToLeft(t *testing.T) {
 			WaitDoneWorker("child2"),
 		),
 		[]cap.Opt{
-			cap.WithOrder(cap.RightToLeft),
+			cap.WithStartOrder(cap.RightToLeft),
 		},
 		func(EventManager) {},
 	)


### PR DESCRIPTION
### Problem

The `WithOrder` supervisor option is not as clear as it could be. 

### Solution

This PR deprecates that name in favor of `WithStartOrder`, which clearly state what is the order being set.

