### PR TITLE
Fix bug on supervision tree termination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v8
-      - uses: cachix/cachix-action@v6
+      - uses: cachix/install-nix-action@v12
+      - uses: cachix/cachix-action@v8
         with:
           name: capatazlib
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/cap/error.go
+++ b/cap/error.go
@@ -1,8 +1,10 @@
 package cap
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/capatazlib/go-capataz/internal/c"
 )
@@ -66,25 +68,35 @@ func (se *SupervisorError) KVs() map[string]interface{} {
 
 // Error returns an error message
 func (se *SupervisorError) Error() string {
-	// NOTE: We are not reporting error details on the string given we want to
-	// rely on structured logging via KVs
-	if (se.nodeErr != nil || len(se.nodeErrMap) > 0) && se.rscCleanupErr != nil {
-		return fmt.Sprintf(
-			"supervisor error: %v "+
-				"(and resource cleanup failed as well)",
-			se.nodeErr,
-		)
-	} else if se.nodeErr != nil {
-		return fmt.Sprintf("supervisor error: %v", se.nodeErr)
-	} else if se.rscCleanupErr != nil {
-		return "supervisor error: failed to cleanup resources"
+	sections := make([]string, 0, 5)
+	sections = append(sections, "\nsupervision tree termination failed")
+
+	if se.nodeErr != nil {
+		var buffer bytes.Buffer
+		buffer.WriteString("* cause error\n\n")
+		buffer.WriteString(fmt.Sprintf("\t%v\n", se.nodeErr))
+		sections = append(sections, buffer.String())
 	}
-	// NOTE: this case never happens, an invariant condition of this type has not
-	// been respected. If we are here, it means we manually created a wrong
-	// SupervisorError value (implementation error).
-	panic(
-		errors.New("invalid SupervisorError was created"),
-	)
+
+	if se.rscCleanupErr != nil {
+		var buffer bytes.Buffer
+		buffer.WriteString("* resource cleanup error\n\n")
+		buffer.WriteString(fmt.Sprintf("\t%v\n", se.rscCleanupErr))
+		sections = append(sections, buffer.String())
+	}
+
+	if len(se.nodeErrMap) > 0 {
+		var buffer bytes.Buffer
+		buffer.WriteString("* children with termination errors\n\n")
+		for siblingName, siblingErr := range se.nodeErrMap {
+			buffer.WriteString(fmt.Sprintf("\t- %s: %v\n", siblingName, siblingErr))
+		}
+		sections = append(sections, buffer.String())
+	}
+
+	sections = append(sections, "")
+
+	return strings.Join(sections, "\n\n")
 }
 
 // SupervisorRestartError wraps an error tolerance surpassed error from a child

--- a/cap/error.go
+++ b/cap/error.go
@@ -1,7 +1,6 @@
 package cap
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -72,21 +71,21 @@ func (se *SupervisorError) Error() string {
 	sections = append(sections, "\nsupervision tree termination failed")
 
 	if se.nodeErr != nil {
-		var buffer bytes.Buffer
+		var buffer strings.Builder
 		buffer.WriteString("* cause error\n\n")
 		buffer.WriteString(fmt.Sprintf("\t%v\n", se.nodeErr))
 		sections = append(sections, buffer.String())
 	}
 
 	if se.rscCleanupErr != nil {
-		var buffer bytes.Buffer
+		var buffer strings.Builder
 		buffer.WriteString("* resource cleanup error\n\n")
 		buffer.WriteString(fmt.Sprintf("\t%v\n", se.rscCleanupErr))
 		sections = append(sections, buffer.String())
 	}
 
 	if len(se.nodeErrMap) > 0 {
-		var buffer bytes.Buffer
+		var buffer strings.Builder
 		buffer.WriteString("* children with termination errors\n\n")
 		for siblingName, siblingErr := range se.nodeErrMap {
 			buffer.WriteString(fmt.Sprintf("\t- %s: %v\n", siblingName, siblingErr))

--- a/cap/supervisor_test.go
+++ b/cap/supervisor_test.go
@@ -8,6 +8,7 @@ package cap_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -316,6 +317,18 @@ func TestFailedTerminationOnOneLevelTree(t *testing.T) {
 	)
 
 	assert.Error(t, err)
+	errMsg := []string{
+		"\nsupervision tree termination failed",
+		"* children with termination errors",
+		"\t- child1: child1 failed\n",
+		"",
+	}
+	assert.Equal(
+		t,
+		strings.Join(errMsg, "\n\n"),
+		err.Error(),
+	)
+
 	t.Run("starts and stops routines in the correct order", func(t *testing.T) {
 		AssertExactMatch(t, events,
 			[]EventP{

--- a/cap/supervisor_test.go
+++ b/cap/supervisor_test.go
@@ -7,6 +7,7 @@ package cap_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -299,4 +300,33 @@ func TestDoubleTermination(t *testing.T) {
 			SupervisorTerminated("root"),
 		},
 	)
+}
+
+func TestFailedTerminationOnOneLevelTree(t *testing.T) {
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		"root",
+		cap.WithNodes(
+			WaitDoneWorker("child0"),
+			FailTerminationWorker("child1", fmt.Errorf("child1 failed")),
+			WaitDoneWorker("child2"),
+		),
+		[]cap.Opt{},
+		func(EventManager) {},
+	)
+
+	assert.Error(t, err)
+	t.Run("starts and stops routines in the correct order", func(t *testing.T) {
+		AssertExactMatch(t, events,
+			[]EventP{
+				WorkerStarted("root/child0"),
+				WorkerStarted("root/child1"),
+				WorkerStarted("root/child2"),
+				SupervisorStarted("root"),
+				WorkerTerminated("root/child2"),
+				WorkerFailedWith("root/child1", "child1 failed"),
+				WorkerTerminated("root/child0"),
+				SupervisorFailed("root"),
+			})
+	})
 }

--- a/internal/stest/workers.go
+++ b/internal/stest/workers.go
@@ -157,3 +157,21 @@ func CompleteOnSignalWorker(
 		opts...,
 	), startSignal
 }
+
+// FailTerminationWorker creates a `cap.Node` that runs a goroutine that blocks
+// until the `context.Done` channel indicates a supervisor termination, then, it
+// returns a given error
+func FailTerminationWorker(
+	name string,
+	err error,
+	opts ...cap.WorkerOpt,
+) cap.Node {
+	cspec := cap.NewWorker(name, func(ctx context.Context) error {
+		// In real-world code, here we would have some business logic. For this
+		// particular scenario, we want to block until we get a stop notification
+		// from our parent supervisor and return an error
+		<-ctx.Done()
+		return err
+	})
+	return cspec
+}


### PR DESCRIPTION
## Problem:

When a child was returning an error on termination, the API was throwing a panic
about an invalid SupervisorError record being created.

This was an implementation error that needed to be addressed.

## Solution:

* We created a test that replicated the issue at hand, and improved the
implementation of the Error method from the SupervisorError type.

* We also improved upon the reported message, building sections on the error
message.