### PR TITLE
kaizen: Ensure process names in events have all their runtime path

### DIFF
--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -99,17 +99,12 @@ func sendNotificationToSup(
 // ChildSpec, this function will block until the spawned goroutine notifies it
 // has been initialized.
 //
-// ### The notifyResult callback
+// ### The supNotifyCh value
 //
-// This callback notifies this child's supervisor that the goroutine has
-// finished (either with or without an error). The runtime name of the child is
-// also given so that the supervisor can use the spec for that child when
-// restarting.
-//
-// #### Why a callback?
-//
-// By using a callback we avoid coupling the Supervisor types to the Child
-// logic.
+// Messages sent to this channel notify the supervisor that the child's
+// goroutine has finished (either with or without an error). The runtime name of
+// the child is also given so that the supervisor can use the spec for that
+// child when restarting.
 //
 func (chSpec ChildSpec) DoStart(
 	supName string,

--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+// workerNameKey is an internal representation of the worker name in the
+// worker context. If you reverse engineer, you are on your own.
+//
 var workerNameKey = "__capataz.worker.runtime_name__"
 
 // GetWorkerName gets a capataz worker name from a context
@@ -19,7 +22,7 @@ func GetWorkerName(ctx context.Context) string {
 }
 
 // setWorkerName allows to add a capataz worker name to a context
-func SetWorkerName(ctx context.Context, name string) context.Context {
+func setWorkerName(ctx context.Context, name string) context.Context {
 	return context.WithValue(ctx, workerNameKey, name)
 }
 
@@ -117,7 +120,7 @@ func (chSpec ChildSpec) DoStart(
 	// events with it's full name
 
 	childCtx, cancelFn := context.WithCancel(
-		SetWorkerName(context.Background(), chRuntimeName),
+		setWorkerName(context.Background(), chRuntimeName),
 	)
 
 	startCh := make(chan startError)

--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -8,10 +8,13 @@ import (
 	"time"
 )
 
+// capatazKey is an internal type for the capataz keys
+type capatazKey string
+
 // workerNameKey is an internal representation of the worker name in the
 // worker context. If you reverse engineer, you are on your own.
 //
-var workerNameKey = "__capataz.worker.runtime_name__"
+var workerNameKey capatazKey = "__capataz.worker.runtime_name__"
 
 // GetWorkerName gets a capataz worker name from a context
 func GetWorkerName(ctx context.Context) string {


### PR DESCRIPTION
### Context

When having supervision trees with more than 3 nested sub-trees, the reporting messages do not have the whole supervision tree path. Changes in this PR fix that bug.

### Acceptance Criteria

* [x] We test very tall trees and assert that all notified events are reported with their full name