### PR TITLE
kaizen: allow workers to inherit context used on Start call

### DIFF
--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -14,6 +14,7 @@ type ctrlMsg interface {
 	// processMsg receives all the required supervisor state to fullfill
 	// its purpose
 	processMsg(
+		supCtx context.Context,
 		evNotifier EventNotifier,
 		spec SupervisorSpec,
 		specChildren []c.ChildSpec,
@@ -37,6 +38,7 @@ type startChildMsg struct {
 }
 
 func (scm startChildMsg) processMsg(
+	supCtx context.Context,
 	evNotifier EventNotifier,
 	spec SupervisorSpec,
 	specChildren []c.ChildSpec,
@@ -48,7 +50,7 @@ func (scm startChildMsg) processMsg(
 
 	childSpec := scm.node(spec)
 
-	ch, startErr := startChildNode(spec, supRuntimeName, supNotifyCh, childSpec)
+	ch, startErr := startChildNode(supCtx, spec, supRuntimeName, supNotifyCh, childSpec)
 	if startErr != nil {
 		// When we fail, we send an error to the supNotifyCh and return the error,
 		// this doesn't have any detrimental consequence in static supervisors,
@@ -99,6 +101,7 @@ type terminateChildMsg struct {
 }
 
 func (tcm terminateChildMsg) processMsg(
+	supCtx context.Context,
 	evNotifier EventNotifier,
 	spec SupervisorSpec,
 	specChildren []c.ChildSpec,
@@ -154,6 +157,7 @@ type DynSupervisor struct {
 // handleCtrlMsg is used in the supervisor monitor loop to operator over public
 // API calls like Spawn or Cancel a child node.
 func handleCtrlMsg(
+	supCtx context.Context,
 	eventNotifier EventNotifier,
 	spec SupervisorSpec,
 	specChildren []c.ChildSpec,
@@ -163,6 +167,7 @@ func handleCtrlMsg(
 	msg ctrlMsg,
 ) ([]c.ChildSpec, map[string]c.Child) {
 	return msg.processMsg(
+		supCtx,
 		eventNotifier,
 		spec,
 		specChildren,

--- a/cap/one_for_one.go
+++ b/cap/one_for_one.go
@@ -1,6 +1,7 @@
 package cap
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 )
 
 func oneForOneRestart(
+	supCtx context.Context,
 	eventNotifier EventNotifier,
 	supRuntimeName string,
 	supChildren map[string]c.Child,
@@ -20,7 +22,7 @@ func oneForOneRestart(
 	chName := chSpec.GetName()
 
 	startTime := time.Now()
-	newCh, chRestartErr := prevCh.Restart(supRuntimeName, supNotifyCh, wasComplete, prevErr)
+	newCh, chRestartErr := prevCh.Restart(supCtx, supRuntimeName, supNotifyCh, wasComplete, prevErr)
 
 	if chRestartErr != nil {
 		return c.Child{}, chRestartErr
@@ -37,6 +39,7 @@ func oneForOneRestart(
 }
 
 func oneForOneRestartLoop(
+	supCtx context.Context,
 	eventNotifier EventNotifier,
 	supRuntimeName string,
 	supChildren map[string]c.Child,
@@ -47,6 +50,7 @@ func oneForOneRestartLoop(
 ) *c.ErrorToleranceReached {
 	for {
 		newCh, restartErr := oneForOneRestart(
+			supCtx,
 			eventNotifier,
 			supRuntimeName,
 			supChildren,

--- a/cap/root.go
+++ b/cap/root.go
@@ -36,6 +36,29 @@ func buildRuntimeName(spec SupervisorSpec, parentName string) string {
 	return runtimeName
 }
 
+type capatazSupKey string
+
+var eventNotifierKey capatazSupKey = "__capataz.node.event_notifier__"
+
+// withEventNotifier sets the Capataz EventNotifier in the context that is
+// thread-through across all capataz logic
+func withEventNotifier(ctx context.Context, evNotifier EventNotifier) context.Context {
+	return context.WithValue(ctx, eventNotifierKey, evNotifier)
+}
+
+// getEventNotifier returns the EventNotifier that is thread-through all the
+// capataz API
+func getEventNotifier(ctx context.Context) (EventNotifier, bool) {
+	val := ctx.Value(eventNotifierKey)
+	if val != nil {
+		if evNotifier, ok := val.(EventNotifier); ok {
+			return evNotifier, true
+		}
+		return nil, false
+	}
+	return nil, false
+}
+
 // rootStart is routine that contains the main logic of a Supervisor. This
 // function:
 //

--- a/cap/spec.go
+++ b/cap/spec.go
@@ -286,8 +286,8 @@ func NewSupervisorSpec(name string, buildNodes BuildNodesFn, opts ...Opt) Superv
 // in reverse order all the child nodes that have been started, finally
 // returning an error value.
 //
-func (spec SupervisorSpec) Start(parentCtx context.Context) (Supervisor, error) {
-	sup, err := spec.rootStart(parentCtx, rootSupervisorName)
+func (spec SupervisorSpec) Start(startCtx context.Context) (Supervisor, error) {
+	sup, err := spec.rootStart(startCtx, rootSupervisorName)
 	if err != nil {
 		return Supervisor{}, err
 	}

--- a/cap/subtree.go
+++ b/cap/subtree.go
@@ -4,6 +4,7 @@ package cap
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/capatazlib/go-capataz/internal/c"
@@ -68,7 +69,10 @@ func subtreeMain(
 	return func(parentCtx context.Context, notifyChildStart c.NotifyStartFn) error {
 		// in this function we use the private versions of run given we don't want
 		// to spawn yet another goroutine
-		supRuntimeName := c.GetWorkerName(parentCtx)
+		supRuntimeName, ok := c.GetNodeName(parentCtx)
+		if !ok {
+			return fmt.Errorf("library bug: subtree context does not have a name")
+		}
 		ctx, cancelFn := context.WithCancel(parentCtx)
 		defer cancelFn()
 		return supSpec.run(ctx, supRuntimeName, notifyChildStart)

--- a/cap/worker_options.go
+++ b/cap/worker_options.go
@@ -120,3 +120,7 @@ var WithTag = c.WithTag
 //   //
 //   WithTolerance(10, 5 * time.Second)
 var WithTolerance = c.WithTolerance
+
+// GetWorkerName returns the runtime name of a supervised goroutine by plucking it
+// up from the given context.
+var GetWorkerName = c.GetNodeName

--- a/cap/worker_test.go
+++ b/cap/worker_test.go
@@ -1,0 +1,150 @@
+package cap_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/cap"
+	. "github.com/capatazlib/go-capataz/internal/stest"
+)
+
+func TestWorkerHasContextValuesOnSimpleTree(t *testing.T) {
+	ctx := context.Background()
+
+	valueOne := 123
+	valueTwo := 456
+
+	ctx = context.WithValue(ctx, "value_one", 123)
+	ctx = context.WithValue(ctx, "value_two", 456)
+
+	worker := cap.NewWorker("one", func(ctx context.Context) error {
+		v1 := ctx.Value("value_one").(int)
+		assert.Equal(t, valueOne, v1)
+
+		v2 := ctx.Value("value_two").(int)
+		assert.Equal(t, valueTwo, v2)
+
+		<-ctx.Done()
+		return nil
+	})
+
+	events, err := ObserveSupervisor(
+		ctx,
+		"root",
+		cap.WithNodes(worker),
+		[]cap.Opt{},
+		func(EventManager) {},
+	)
+
+	assert.NoError(t, err)
+	AssertExactMatch(t, events,
+		[]EventP{
+			WorkerStarted("root/one"),
+			SupervisorStarted("root"),
+			WorkerTerminated("root/one"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestWorkerHasContextValuesOnNestedTree(t *testing.T) {
+	ctx := context.Background()
+
+	valueOne := 123
+	valueTwo := 456
+
+	ctx = context.WithValue(ctx, "value_one", 123)
+	ctx = context.WithValue(ctx, "value_two", 456)
+
+	worker := cap.NewWorker("one", func(ctx context.Context) error {
+		v1 := ctx.Value("value_one").(int)
+		assert.Equal(t, valueOne, v1)
+
+		v2 := ctx.Value("value_two").(int)
+		assert.Equal(t, valueTwo, v2)
+
+		<-ctx.Done()
+		return nil
+	})
+
+	tree1 := cap.NewSupervisorSpec("subtree", cap.WithNodes(worker))
+
+	events, err := ObserveSupervisor(
+		ctx,
+		"root",
+		cap.WithNodes(
+			cap.Subtree(tree1),
+		),
+		[]cap.Opt{},
+		func(EventManager) {},
+	)
+
+	assert.NoError(t, err)
+	AssertExactMatch(t, events,
+		[]EventP{
+			WorkerStarted("root/subtree/one"),
+			SupervisorStarted("root/subtree"),
+			SupervisorStarted("root"),
+			WorkerTerminated("root/subtree/one"),
+			SupervisorTerminated("root/subtree"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestWorkerContextCanGetNameOnNestedSubtree(t *testing.T) {
+	ctx := context.Background()
+
+	newWorker := func(prefix, expected string) cap.Node {
+		worker := cap.NewWorker(expected, func(ctx context.Context) error {
+			name, ok := cap.GetWorkerName(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, fmt.Sprintf("%s/%s", prefix, expected), name)
+			<-ctx.Done()
+			return nil
+		})
+		return worker
+	}
+
+	worker1 := newWorker("root/subtree1", "one")
+	worker2 := newWorker("root/subtree2", "two")
+	worker3 := newWorker("root/subtree1/subtree3", "three")
+
+	tree3 := cap.NewSupervisorSpec("subtree3", cap.WithNodes(worker3))
+	tree1 := cap.NewSupervisorSpec("subtree1", cap.WithNodes(worker1, cap.Subtree(tree3)))
+	tree2 := cap.NewSupervisorSpec("subtree2", cap.WithNodes(worker2))
+
+	events, err := ObserveSupervisor(
+		ctx,
+		"root",
+		cap.WithNodes(
+			cap.Subtree(tree1),
+			cap.Subtree(tree2),
+		),
+		[]cap.Opt{},
+		func(EventManager) {},
+	)
+
+	assert.NoError(t, err)
+	AssertExactMatch(t, events,
+		[]EventP{
+			WorkerStarted("root/subtree1/one"),
+			WorkerStarted("root/subtree1/subtree3/three"),
+			SupervisorStarted("root/subtree1/subtree3"),
+			SupervisorStarted("root/subtree1"),
+			WorkerStarted("root/subtree2/two"),
+			SupervisorStarted("root/subtree2"),
+			SupervisorStarted("root"),
+			WorkerTerminated("root/subtree2/two"),
+			SupervisorTerminated("root/subtree2"),
+			WorkerTerminated("root/subtree1/subtree3/three"),
+			SupervisorTerminated("root/subtree1/subtree3"),
+			WorkerTerminated("root/subtree1/one"),
+			SupervisorTerminated("root/subtree1"),
+			SupervisorTerminated("root"),
+		},
+	)
+}

--- a/internal/c/no_cancel_ctx.go
+++ b/internal/c/no_cancel_ctx.go
@@ -1,0 +1,20 @@
+package c
+
+import (
+	"context"
+	"time"
+)
+
+type noCancel struct {
+	ctx context.Context
+}
+
+func (c noCancel) Deadline() (time.Time, bool)       { return time.Time{}, false }
+func (c noCancel) Done() <-chan struct{}             { return nil }
+func (c noCancel) Err() error                        { return nil }
+func (c noCancel) Value(key interface{}) interface{} { return c.ctx.Value(key) }
+
+// WithoutCancel returns a context that is never canceled.
+func WithoutCancel(ctx context.Context) context.Context {
+	return noCancel{ctx: ctx}
+}

--- a/internal/c/no_cancel_ctx.go
+++ b/internal/c/no_cancel_ctx.go
@@ -6,15 +6,14 @@ import (
 )
 
 type noCancel struct {
-	ctx context.Context
+	context.Context
 }
 
-func (c noCancel) Deadline() (time.Time, bool)       { return time.Time{}, false }
-func (c noCancel) Done() <-chan struct{}             { return nil }
-func (c noCancel) Err() error                        { return nil }
-func (c noCancel) Value(key interface{}) interface{} { return c.ctx.Value(key) }
+func (c noCancel) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c noCancel) Done() <-chan struct{}       { return nil }
+func (c noCancel) Err() error                  { return nil }
 
 // WithoutCancel returns a context that is never canceled.
 func WithoutCancel(ctx context.Context) context.Context {
-	return noCancel{ctx: ctx}
+	return noCancel{ctx}
 }

--- a/internal/c/restart.go
+++ b/internal/c/restart.go
@@ -1,5 +1,7 @@
 package c
 
+import "context"
+
 func (ch Child) assertErrorTolerance(err error) (uint32, *ErrorToleranceReached) {
 	errTolerance := ch.spec.ErrTolerance
 	switch errTolerance.check(ch.restartCount, ch.createdAt) {
@@ -22,6 +24,7 @@ func (ch Child) assertErrorTolerance(err error) (uint32, *ErrorToleranceReached)
 
 // Restart spawns a new Child and keeps track of the restart count.
 func (ch Child) Restart(
+	startCtx context.Context,
 	supParentName string,
 	supNotifyCh chan<- ChildNotification,
 	wasComplete bool,
@@ -33,7 +36,7 @@ func (ch Child) Restart(
 	var startErr error
 
 	if wasComplete {
-		newCh, startErr = chSpec.DoStart(supParentName, supNotifyCh)
+		newCh, startErr = chSpec.DoStart(startCtx, supParentName, supNotifyCh)
 		if startErr != nil {
 			return Child{}, startErr
 		}
@@ -42,7 +45,7 @@ func (ch Child) Restart(
 		if toleranceErr != nil {
 			return Child{}, toleranceErr
 		}
-		newCh, startErr = chSpec.DoStart(supParentName, supNotifyCh)
+		newCh, startErr = chSpec.DoStart(startCtx, supParentName, supNotifyCh)
 		if startErr != nil {
 			return Child{}, startErr
 		}

--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -114,6 +114,7 @@ func sendNotificationToSup(
 // child when restarting.
 //
 func (chSpec ChildSpec) DoStart(
+	startCtx context.Context,
 	supName string,
 	supNotifyCh chan<- ChildNotification,
 ) (Child, error) {

--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -11,22 +11,23 @@ import (
 // capatazKey is an internal type for the capataz keys
 type capatazKey string
 
-// workerNameKey is an internal representation of the worker name in the
+// nodeNameKey is an internal representation of the worker name in the
 // worker context. If you reverse engineer, you are on your own.
 //
-var workerNameKey capatazKey = "__capataz.worker.runtime_name__"
+var nodeNameKey capatazKey = "__capataz.node.runtime_name__"
 
-// GetWorkerName gets a capataz worker name from a context
-func GetWorkerName(ctx context.Context) string {
-	if val := ctx.Value(workerNameKey); val != nil {
-		return val.(string)
+// GetNodeName gets a capataz worker name from a context
+func GetNodeName(ctx context.Context) (string, bool) {
+	if val := ctx.Value(nodeNameKey); val != nil {
+		result, ok := val.(string)
+		return result, ok
 	}
-	return ""
+	return "", false
 }
 
-// setWorkerName allows to add a capataz worker name to a context
-func setWorkerName(ctx context.Context, name string) context.Context {
-	return context.WithValue(ctx, workerNameKey, name)
+// setNodeName allows to add a capataz worker name to a context
+func setNodeName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, nodeNameKey, name)
 }
 
 // waitTimeout is the internal function used by Child to wait for the execution
@@ -119,12 +120,13 @@ func (chSpec ChildSpec) DoStart(
 
 	chRuntimeName := strings.Join([]string{supName, chSpec.GetName()}, "/")
 
-	// we allow a worker to know it's name so as to allow subtrees to report
-	// events with it's full name
+	// we remove the cancel from the context received on the start call so that we
+	// don't end up canceling the children at a non-appropiate time
+	ctx := WithoutCancel(startCtx)
 
-	childCtx, cancelFn := context.WithCancel(
-		setWorkerName(context.Background(), chRuntimeName),
-	)
+	// we allow a node to know it's name so as to allow subtrees to report
+	// events with it's full name
+	childCtx, cancelFn := context.WithCancel(setNodeName(ctx, chRuntimeName))
 
 	startCh := make(chan startError)
 	terminateCh := make(chan ChildNotification)


### PR DESCRIPTION
### Context

As a way to design applications that make use of context to get general purpose values (loggers, metrics, etc.), we want to allow capataz workers to inherit the key-values set on the context that is used on the `supervisor.Start` call.

### Acceptance Criteria

* [x] Values set on the context before we perform the `Start` call are available to all the workers of a supervision tree
* [x] We allow workers to know their runtime name (may be used for enhancing business domain log tracing)