### PR TITLE
Add support for Dynamic Subtrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+## v0.0.1
+
+* Introducing `NewDynSubtree` to allow workers that can spawn workers dynamically
+
+* Ensure test `EventManager` event collection is concurrent-safe
+
+* Ensure `Terminate` and `Wait` calls on `DynSupervisors` are idempotent
+
+* Fix `ObserveSupervisor` functions to not leak event collector goroutines
+
+* Rename of internal variables for enhanced readbility
+
+## v0.0.0
+
+* No consistent tracking of changes before release, please check closed PR's
+  up till #53

--- a/cap/dyn_subtree.go
+++ b/cap/dyn_subtree.go
@@ -1,0 +1,95 @@
+package cap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/capatazlib/go-capataz/internal/c"
+)
+
+// Spawner is a record that can spawn other workers, and can wait
+// for termination
+type Spawner interface {
+	Spawn(Node) (func() error, error)
+	Wait() error
+}
+
+// NewDynSubtree builds a worker that has receives a Spawner that allows it to
+// create more child workers dynamically in a sub-tree.
+//
+// Note: The Spawner is automatically managed by the supervision tree, so
+// clients are not required to terminate it explicitly.
+//
+func NewDynSubtree(
+	name string,
+	startFn func(context.Context, Spawner) error,
+	spawnerOpts []Opt,
+	opts ...WorkerOpt,
+) Node {
+	return NewDynSubtreeWithNotifyStart(
+		name,
+		func(ctx context.Context, notifyStart NotifyStartFn, spawner Spawner) error {
+			notifyStart(nil)
+			return startFn(ctx, spawner)
+		},
+		spawnerOpts,
+		opts...,
+	)
+}
+
+// NewDynSubtreeWithNotifyStart accomplishes the same goal as NewDynSubtree with
+// the addition of passing an extra argument (notifyStart callback) to the
+// startFn function parameter.
+func NewDynSubtreeWithNotifyStart(
+	name string,
+	startFn func(context.Context, NotifyStartFn, Spawner) error,
+	spawnerOpts []Opt,
+	opts ...WorkerOpt,
+) Node {
+	return func(supSpec SupervisorSpec) c.ChildSpec {
+		return c.NewWithNotifyStart(
+			name,
+			func(parentCtx context.Context, notifyChildStart c.NotifyStartFn) error {
+				workerRuntimeName, ok := c.GetNodeName(parentCtx)
+				if !ok {
+					return fmt.Errorf("library bug: subtree context does not have a name")
+				}
+
+				spawnerName := strings.Join([]string{workerRuntimeName, "subtree-spawner"}, "/")
+
+				spawnerOpts = append(spawnerOpts, WithNotifier(supSpec.eventNotifier))
+				dynSup, dynSupErr := NewDynSupervisor(parentCtx, spawnerName, spawnerOpts...)
+				if dynSupErr != nil {
+					notifyChildStart(dynSupErr)
+					return dynSupErr
+				}
+
+				// ensure supervisor is terminated if startFn raises a panic.
+				defer dynSup.Terminate()
+
+				workerErr := startFn(parentCtx, notifyChildStart, &dynSup)
+
+				// we can call Terminate multiple times as it is idempotent
+				terminationErr := dynSup.Terminate()
+
+				// when the spawner fails to terminate, we want to report the error of
+				// this worker as a supervisor error
+				if terminationErr != nil {
+					nodeErrMap := map[string]error{}
+					nodeErrMap[spawnerName] = terminationErr
+					dynSubtreeErr := &SupervisorTerminationError{
+						supRuntimeName: workerRuntimeName,
+						nodeErrMap:     nodeErrMap,
+						rscCleanupErr:  nil,
+					}
+					return dynSubtreeErr
+				}
+
+				// otherwise, return the error as if you were a worker
+				return workerErr
+			},
+			opts...,
+		)
+	}
+}

--- a/cap/dyn_subtree_test.go
+++ b/cap/dyn_subtree_test.go
@@ -2,7 +2,7 @@ package cap_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before
-// supervisors in the assertions bellow, check stest/README.md
+// supervisors in the assertions below, check stest/README.md
 //
 
 import (

--- a/cap/dyn_subtree_test.go
+++ b/cap/dyn_subtree_test.go
@@ -1,0 +1,121 @@
+package cap_test
+
+//
+// NOTE: If you feel it is counter-intuitive to have workers start before
+// supervisors in the assertions bellow, check stest/README.md
+//
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/cap"
+	. "github.com/capatazlib/go-capataz/internal/stest"
+)
+
+func TestDynSubtreeStartSingleChild(t *testing.T) {
+	events, errs := ObserveSupervisor(
+		context.TODO(),
+		"root",
+		cap.WithNodes(
+			WaitDoneDynSubtree(
+				"one", []cap.Opt{}, []cap.WorkerOpt{}, WaitDoneWorker("uno"),
+			),
+		),
+		[]cap.Opt{},
+		func(EventManager) {},
+	)
+	assert.Empty(t, errs)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// The subtree-spawner starts first, as it is the initial logic
+			// of the DynSubTree worker
+			SupervisorStarted("root/one/subtree-spawner"),
+			WorkerStarted("root/one/subtree-spawner/uno"),
+			// Every spawn call for the subtree-spawner blocks until it is received
+			WorkerStarted("root/one"),
+			SupervisorStarted("root"),
+			WorkerTerminated("root/one/subtree-spawner/uno"),
+			SupervisorTerminated("root/one/subtree-spawner"),
+			WorkerTerminated("root/one"),
+			SupervisorTerminated("root"),
+		})
+}
+
+func TestDynSubtreeFailing(t *testing.T) {
+	// Fail only one time
+	child1, failSubtree1 := FailOnSignalDynSubtree(
+		1,
+		"one",
+		[]cap.Opt{},
+		[]cap.WorkerOpt{},
+		WaitDoneWorker("uno"),
+		WaitDoneWorker("dos"),
+		WaitDoneWorker("tres"),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		"root",
+		cap.WithNodes(child1),
+		[]cap.Opt{},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			failSubtree1(true /* done */)
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerStarted("root/one"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// dynamic supervisor will start before the worker that
+			// contains it
+			SupervisorStarted("root/one/subtree-spawner"),
+			// then the dyn supervisor children
+			WorkerStarted("root/one/subtree-spawner/uno"),
+			WorkerStarted("root/one/subtree-spawner/dos"),
+			WorkerStarted("root/one/subtree-spawner/tres"),
+			// then dyn subtree worker
+			WorkerStarted("root/one"),
+			// finally the root supervisor
+			SupervisorStarted("root"),
+
+			// *signal of error starts here*
+
+			// dyn subtree terminates in reverse order
+			WorkerTerminated("root/one/subtree-spawner/tres"),
+			WorkerTerminated("root/one/subtree-spawner/dos"),
+			WorkerTerminated("root/one/subtree-spawner/uno"),
+			SupervisorTerminated("root/one/subtree-spawner"),
+
+			// then sub tree worker terminated
+			WorkerFailed("root/one"),
+
+			// * restart starts here *
+			SupervisorStarted("root/one/subtree-spawner"),
+			WorkerStarted("root/one/subtree-spawner/uno"),
+			WorkerStarted("root/one/subtree-spawner/dos"),
+			WorkerStarted("root/one/subtree-spawner/tres"),
+			WorkerStarted("root/one"),
+
+			// After 1st (re)start we stop
+			WorkerTerminated("root/one/subtree-spawner/tres"),
+			WorkerTerminated("root/one/subtree-spawner/dos"),
+			WorkerTerminated("root/one/subtree-spawner/uno"),
+			SupervisorTerminated("root/one/subtree-spawner"),
+			WorkerTerminated("root/one"),
+			SupervisorTerminated("root"),
+		},
+	)
+}

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -279,6 +279,10 @@ func (dyn *DynSupervisor) Spawn(nodeFn Node) (func() error, error) {
 // Terminate is a synchronous procedure that halts the execution of the whole
 // supervision tree.
 func (dyn *DynSupervisor) Terminate() error {
+	if dyn.terminated {
+		return dyn.terminationErr
+	}
+
 	dyn.terminationErr = dyn.sup.Terminate()
 	dyn.terminated = true
 	return dyn.terminationErr
@@ -287,7 +291,13 @@ func (dyn *DynSupervisor) Terminate() error {
 // Wait blocks the execution of the current goroutine until the Supervisor
 // finishes it execution.
 func (dyn DynSupervisor) Wait() error {
-	return dyn.sup.Wait()
+	if dyn.terminated {
+		return dyn.terminationErr
+	}
+
+	dyn.terminationErr = dyn.sup.Wait()
+	dyn.terminated = true
+	return dyn.terminationErr
 }
 
 // GetName returns the name of the Spec used to start this Supervisor

--- a/cap/dyn_supervisor.go
+++ b/cap/dyn_supervisor.go
@@ -68,7 +68,6 @@ func (scm startChildMsg) processMsg(
 		}
 
 		return specChildren, supChildren
-
 	}
 
 	// We store the child to the spec list because we need to terminate them
@@ -177,7 +176,7 @@ func handleCtrlMsg(
 	)
 }
 
-func (dyn *DynSupervisor) terminateNode(nodeName string) func() error {
+func (dyn *DynSupervisor) buildTerminateNodeCallback(nodeName string) func() error {
 	// REMEMBER: WE ARE RUNNING ON THE CLIENT API THREAD
 
 	// we initialize the resultCh with a buffer of 1, we may store the result
@@ -269,7 +268,7 @@ func (dyn *DynSupervisor) Spawn(nodeFn Node) (func() error, error) {
 		if result.startErr != nil {
 			return nil, result.startErr
 		}
-		return dyn.terminateNode(result.childName), nil
+		return dyn.buildTerminateNodeCallback(result.childName), nil
 	case <-time.After(1 * time.Second):
 		// Paranoid timeout. Better to not hang if this ever happens; to be honest,
 		// not sure when this is the case :shrug:

--- a/cap/dyn_supervisor_test.go
+++ b/cap/dyn_supervisor_test.go
@@ -2,7 +2,7 @@ package cap_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before
-// supervisors in the assertions bellow, check stest/README.md
+// supervisors in the assertions below, check stest/README.md
 //
 
 import (
@@ -57,7 +57,7 @@ func TestDynStartMutlipleChildrenLeftToRight(t *testing.T) {
 		AssertExactMatch(t, events,
 			[]EventP{
 				SupervisorStarted("root"),
-				// ^^^ root starts first because we add workers bellow in a procedural
+				// ^^^ root starts first because we add workers below in a procedural
 				// fashion
 				WorkerStarted("root/child0"),
 				WorkerStarted("root/child1"),
@@ -97,7 +97,7 @@ func TestDynStartMutlipleChildrenRightToLeft(t *testing.T) {
 		AssertExactMatch(t, events,
 			[]EventP{
 				SupervisorStarted("root"),
-				// ^^^ root starts first because we add workers bellow in a procedural
+				// ^^^ root starts first because we add workers below in a procedural
 				// fashion
 				WorkerStarted("root/child0"),
 				WorkerStarted("root/child1"),

--- a/cap/monitor.go
+++ b/cap/monitor.go
@@ -138,7 +138,7 @@ func startChildNode(
 	startedTime := time.Now()
 	ch, chStartErr := chSpec.DoStart(startCtx, supRuntimeName, notifyCh)
 
-	// NOTE: The error handling code bellow gets executed when the children
+	// NOTE: The error handling code below gets executed when the children
 	// fails at start time
 	if chStartErr != nil {
 		cRuntimeName := strings.Join(

--- a/cap/permanent_one_for_one_test.go
+++ b/cap/permanent_one_for_one_test.go
@@ -2,7 +2,7 @@ package cap_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before
-// supervisors in the assertions bellow, check stest/README.md
+// supervisors in the assertions below, check stest/README.md
 //
 
 import (

--- a/cap/supervisor_build_nodes_fn_test.go
+++ b/cap/supervisor_build_nodes_fn_test.go
@@ -2,7 +2,7 @@ package cap_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before
-// supervisors in the assertions bellow, check stest/README.md
+// supervisors in the assertions below, check stest/README.md
 //
 
 import (

--- a/cap/supervisor_test.go
+++ b/cap/supervisor_test.go
@@ -2,7 +2,7 @@ package cap_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before
-// supervisors in the assertions bellow, check stest/README.md
+// supervisors in the assertions below, check stest/README.md
 //
 
 import (

--- a/cap/temporary_one_for_one_test.go
+++ b/cap/temporary_one_for_one_test.go
@@ -2,7 +2,7 @@ package cap_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before
-// supervisors in the assertions bellow, check stest/README.md
+// supervisors in the assertions below, check stest/README.md
 //
 
 import (

--- a/cap/transient_one_for_one_test.go
+++ b/cap/transient_one_for_one_test.go
@@ -2,7 +2,7 @@ package cap_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before
-// supervisors in the assertions bellow, check stest/README.md
+// supervisors in the assertions below, check stest/README.md
 //
 
 import (

--- a/internal/stest/README.md
+++ b/internal/stest/README.md
@@ -45,7 +45,7 @@ want to make sure an event happens before triggering a new one concurrently.
 
 Finally, this function returns two values, the events that got triggered, and if
 the supervisor failed with an error. You can then use the assertion functions
-(described bellow) to check that the events are the ones you expect.
+(described below) to check that the events are the ones you expect.
 
 ### Assertion functions
 

--- a/internal/stest/assertions.go
+++ b/internal/stest/assertions.go
@@ -130,12 +130,15 @@ func AssertPartialMatch(t *testing.T, evs []cap.Event, preds []EventP) {
 // are testing). This function returns the list of events that happened in the monitored
 // supervised tree, as well as any crash errors.
 func ObserveDynSupervisor(
-	ctx context.Context,
+	ctx0 context.Context,
 	rootName string,
 	childNodes []cap.Node,
 	opts0 []cap.Opt,
 	callback func(cap.DynSupervisor, EventManager),
 ) ([]cap.Event, []error) {
+	ctx, done := context.WithCancel(ctx0)
+	defer done()
+
 	evManager := NewEventManager()
 	// Accumulate the events as they happen
 	evManager.StartCollector(ctx)
@@ -247,13 +250,16 @@ func mergeNotifiers(notifiers []cap.EventNotifier) cap.EventNotifier {
 // are testing). This function returns the list of events that happened in the
 // monitored supervised tree, as well as any crash errors.
 func ObserveSupervisorWithNotifiers(
-	ctx context.Context,
+	ctx0 context.Context,
 	rootName string,
 	buildNodes cap.BuildNodesFn,
 	opts0 []cap.Opt,
 	notifiers []cap.EventNotifier,
 	callback func(EventManager),
 ) ([]cap.Event, error) {
+	ctx, stop := context.WithCancel(ctx0)
+	defer stop()
+
 	evManager := NewEventManager()
 	// Accumulate the events as they happen
 	evManager.StartCollector(ctx)

--- a/internal/stest/workers.go
+++ b/internal/stest/workers.go
@@ -9,6 +9,83 @@ import (
 	"github.com/capatazlib/go-capataz/cap"
 )
 
+// WaitDoneDynSubtree creates a `cap.Node` that runs a goroutine with a spawner
+// that will spawn the given children. It blocks until the `context.Done`
+// channel indicates a supervisor termination
+func WaitDoneDynSubtree(
+	name string,
+	spawnerOpts []cap.Opt,
+	workerOpts []cap.WorkerOpt,
+	children ...cap.Node,
+) cap.Node {
+	return cap.NewDynSubtreeWithNotifyStart(
+		name,
+		func(
+			ctx context.Context,
+			notifyStart cap.NotifyStartFn,
+			spawner cap.Spawner,
+		) error {
+			for _, c := range children {
+				_, err := spawner.Spawn(c)
+				if err != nil {
+					notifyStart(err)
+					return err
+				}
+			}
+			notifyStart(nil)
+			return spawner.Wait()
+		},
+		spawnerOpts,
+		workerOpts...,
+	)
+}
+
+// FailOnSignalDynSubtree creates a cap.Node that runs a dynamic subtree that
+// will fail at least the given number of times as soon as the returned start
+// signal is called. Once this number of times has been reached, it waits until
+// the given `context.Done` channel indicates a supervisor termination.
+func FailOnSignalDynSubtree(
+	totalErrCount int32,
+	name string,
+	spawnerOpts []cap.Opt,
+	workerOpts []cap.WorkerOpt,
+	children ...cap.Node,
+) (cap.Node, func(bool)) {
+	currentFailCount := int32(0)
+	startCh := make(chan struct{})
+	startSignal := func(done bool) {
+		if done {
+			close(startCh)
+			return
+		}
+		startCh <- struct{}{}
+	}
+	return cap.NewDynSubtreeWithNotifyStart(
+		name,
+		func(ctx context.Context, notifyStart cap.NotifyStartFn, spawner cap.Spawner) error {
+			for _, c := range children {
+				_, err := spawner.Spawn(c)
+				if err != nil {
+					notifyStart(err)
+					return err
+				}
+			}
+			notifyStart(nil)
+
+			<-startCh
+			if currentFailCount < totalErrCount {
+				atomic.AddInt32(&currentFailCount, 1)
+				return fmt.Errorf(
+					"Failing dyn subtree (%d out of %d)", currentFailCount, totalErrCount,
+				)
+			}
+			return spawner.Wait()
+		},
+		spawnerOpts,
+		workerOpts...,
+	), startSignal
+}
+
 // WaitDoneWorker creates a `cap.Node` that runs a goroutine that blocks until
 // the `context.Done` channel indicates a supervisor termination
 func WaitDoneWorker(name string) cap.Node {


### PR DESCRIPTION
### Context

This API allows to integrate a `DynamicSupervisor` as subtree from a regular `Supervisor`. Previously, a `DynSupervisor` could not be integrated to an already existing static supervision tree.

`NewDynSubtree` allows to create a `Worker` that receives a `Spawner` record that allows the API clients to spawn new workers dynamically in a sub-tree of that worker.

### Considerations

* I do not like that a Worker is the parent of a Supervisor, I'm going to look out ways to have them being siblings on a static subtree.

### Acceptance Criteria

* [x] We can create a worker with spawning capabilities 