### PR TITLE
Move all `cap` files to `internal/s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # pre-release v0.1.0 (breaking changes)
 
-* Deprecate `WithTolerance` worker option with `WithRestartTolerance` supervisor option
+* Deprecate `WithTolerance` worker option with `WithRestartTolerance` supervisor
+  option (#55)
+
+* Move all files in the `cap` folder to `internal/s` and do an explicit export
+  list of symbols (#56)
 
 # v0.0.0
 

--- a/cap/error_exports.go
+++ b/cap/error_exports.go
@@ -1,0 +1,31 @@
+package cap
+
+import "github.com/capatazlib/go-capataz/internal/s"
+
+// ErrKVs is an utility interface used to get key-values out of Capataz errors
+type ErrKVs = s.ErrKVs
+
+// SupervisorTerminationError wraps errors returned by a child node that failed
+// to terminate (io errors, timeouts, etc.), enhancing it with supervisor
+// information. Note, the only way to have a valid SupervisorTerminationError is
+// for one of the child nodes to fail or the supervisor cleanup operation fails.
+type SupervisorTerminationError = s.SupervisorTerminationError
+
+// SupervisorBuildError wraps errors returned from a client provided function
+// that builds the supervisor nodes, enhancing it with supervisor information
+type SupervisorBuildError = s.SupervisorBuildError
+
+// SupervisorStartError wraps an error reported on the initialization of a child
+// node, enhancing it with supervisor information and possible termination errors
+// on other siblings
+type SupervisorStartError = s.SupervisorStartError
+
+// SupervisorRestartError wraps an error tolerance surpassed error from a child
+// node, enhancing it with supervisor information and possible termination errors
+// on other siblings
+type SupervisorRestartError = s.SupervisorRestartError
+
+// RestartToleranceReached is an error that gets reported when a supervisor has
+// restarted a child so many times over a period of time that it does not make
+// sense to keep restarting.
+type RestartToleranceReached = s.RestartToleranceReached

--- a/cap/error_exports.go
+++ b/cap/error_exports.go
@@ -3,29 +3,41 @@ package cap
 import "github.com/capatazlib/go-capataz/internal/s"
 
 // ErrKVs is an utility interface used to get key-values out of Capataz errors
+//
+// Since: 0.0.0
 type ErrKVs = s.ErrKVs
 
 // SupervisorTerminationError wraps errors returned by a child node that failed
 // to terminate (io errors, timeouts, etc.), enhancing it with supervisor
 // information. Note, the only way to have a valid SupervisorTerminationError is
 // for one of the child nodes to fail or the supervisor cleanup operation fails.
+//
+// Since: 0.0.0
 type SupervisorTerminationError = s.SupervisorTerminationError
 
 // SupervisorBuildError wraps errors returned from a client provided function
 // that builds the supervisor nodes, enhancing it with supervisor information
+//
+// Since: 0.0.0
 type SupervisorBuildError = s.SupervisorBuildError
 
 // SupervisorStartError wraps an error reported on the initialization of a child
 // node, enhancing it with supervisor information and possible termination errors
 // on other siblings
+//
+// Since: 0.0.0
 type SupervisorStartError = s.SupervisorStartError
 
 // SupervisorRestartError wraps an error tolerance surpassed error from a child
 // node, enhancing it with supervisor information and possible termination errors
 // on other siblings
+//
+// Since: 0.0.0
 type SupervisorRestartError = s.SupervisorRestartError
 
 // RestartToleranceReached is an error that gets reported when a supervisor has
 // restarted a child so many times over a period of time that it does not make
 // sense to keep restarting.
+//
+// Since: 0.0.0
 type RestartToleranceReached = s.RestartToleranceReached

--- a/cap/event_exports.go
+++ b/cap/event_exports.go
@@ -1,0 +1,34 @@
+package cap
+
+import "github.com/capatazlib/go-capataz/internal/s"
+
+// EventTag specifies the type of Event that gets notified from the supervision
+// system
+type EventTag = s.EventTag
+
+// ProcessStarted is an Event that indicates a process started
+var ProcessStarted = s.ProcessStarted
+
+// ProcessTerminated is an Event that indicates a process was stopped by a
+// parent supervisor
+var ProcessTerminated = s.ProcessTerminated
+
+// ProcessStartFailed is an Event that indicates a process failed to start
+var ProcessStartFailed = s.ProcessStartFailed
+
+// ProcessFailed is an Event that indicates a process reported an error
+var ProcessFailed = s.ProcessFailed
+
+// ProcessCompleted is an Event that indicates a process finished without errors
+var ProcessCompleted = s.ProcessCompleted
+
+// Event is a record emitted by the supervision system. The events are used for
+// multiple purposes, from testing to monitoring the healthiness of the
+// supervision system.
+type Event = s.Event
+
+// EventNotifier is a function that is used for reporting events from the from
+// the supervision system.
+//
+// Check the documentation of WithNotifier for more details.
+type EventNotifier = s.EventNotifier

--- a/cap/event_exports.go
+++ b/cap/event_exports.go
@@ -4,31 +4,47 @@ import "github.com/capatazlib/go-capataz/internal/s"
 
 // EventTag specifies the type of Event that gets notified from the supervision
 // system
+//
+// Since: 0.0.0
 type EventTag = s.EventTag
 
 // ProcessStarted is an Event that indicates a process started
+//
+// Since: 0.0.0
 var ProcessStarted = s.ProcessStarted
 
 // ProcessTerminated is an Event that indicates a process was stopped by a
 // parent supervisor
+//
+// Since: 0.0.0
 var ProcessTerminated = s.ProcessTerminated
 
 // ProcessStartFailed is an Event that indicates a process failed to start
+//
+// Since: 0.0.0
 var ProcessStartFailed = s.ProcessStartFailed
 
 // ProcessFailed is an Event that indicates a process reported an error
+//
+// Since: 0.0.0
 var ProcessFailed = s.ProcessFailed
 
 // ProcessCompleted is an Event that indicates a process finished without errors
+//
+// Since: 0.0.0
 var ProcessCompleted = s.ProcessCompleted
 
 // Event is a record emitted by the supervision system. The events are used for
 // multiple purposes, from testing to monitoring the healthiness of the
 // supervision system.
+//
+// Since: 0.0.0
 type Event = s.Event
 
 // EventNotifier is a function that is used for reporting events from the from
 // the supervision system.
 //
 // Check the documentation of WithNotifier for more details.
+//
+// Since: 0.0.0
 type EventNotifier = s.EventNotifier

--- a/cap/exports.go
+++ b/cap/exports.go
@@ -1,1 +1,0 @@
-package cap

--- a/cap/exports.go
+++ b/cap/exports.go
@@ -1,0 +1,1 @@
+package cap

--- a/cap/healthcheck_exports.go
+++ b/cap/healthcheck_exports.go
@@ -3,13 +3,19 @@ package cap
 import "github.com/capatazlib/go-capataz/internal/s"
 
 // HealthReport contains a report for the HealthMonitor
+//
+// Since: 0.0.0
 type HealthReport = s.HealthReport
 
 // HealthyReport represents a healthy report
+//
+// Since: 0.0.0
 var HealthyReport = s.HealthyReport
 
 // HealthcheckMonitor listens to the events of a supervision tree events, and
 // assess if the supervisor is healthy or not
+//
+// Since: 0.0.0
 type HealthcheckMonitor = s.HealthcheckMonitor
 
 // NewHealthcheckMonitor offers a way to monitor a supervision tree health from
@@ -23,4 +29,6 @@ type HealthcheckMonitor = s.HealthcheckMonitor
 //                            to restart under the threshold results in an
 //                            unhealthy report
 //
+//
+// Since: 0.0.0
 var NewHealthcheckMonitor = s.NewHealthcheckMonitor

--- a/cap/healthcheck_exports.go
+++ b/cap/healthcheck_exports.go
@@ -1,0 +1,26 @@
+package cap
+
+import "github.com/capatazlib/go-capataz/internal/s"
+
+// HealthReport contains a report for the HealthMonitor
+type HealthReport = s.HealthReport
+
+// HealthyReport represents a healthy report
+var HealthyReport = s.HealthyReport
+
+// HealthcheckMonitor listens to the events of a supervision tree events, and
+// assess if the supervisor is healthy or not
+type HealthcheckMonitor = s.HealthcheckMonitor
+
+// NewHealthcheckMonitor offers a way to monitor a supervision tree health from
+// events emitted by it.
+//
+// maxAllowedFailures: the threshold beyond which the environment is considered
+//                     unhealthy.
+//
+// maxAllowedRestartDuration: the restart threshold, which if exceeded, indicates
+//                            an unhealthy environment. Any process that fails
+//                            to restart under the threshold results in an
+//                            unhealthy report
+//
+var NewHealthcheckMonitor = s.NewHealthcheckMonitor

--- a/cap/supervisor_exports.go
+++ b/cap/supervisor_exports.go
@@ -6,35 +6,51 @@ import (
 
 // Node represents a tree node in a supervision tree, it could either be a
 // Subtree or a Worker
+//
+// Since: 0.0.0
 type Node = s.Node
 
 // Order specifies the order in which a supervisor is going to start its node
 // children. The stop order is the reverse of the start order.
+//
+// Since: 0.0.0
 type Order = s.Order
 
 // LeftToRight is an Order that specifies children start from left to right
+//
+// Since: 0.0.0
 var LeftToRight = s.LeftToRight
 
 // RightToLeft is an Order that specifies children start from right to left
+//
+// Since: 0.0.0
 var RightToLeft = s.RightToLeft
 
 // Strategy specifies how children get restarted when one of them reports an
 // error
+//
+// Since: 0.0.0
 type Strategy = s.Strategy
 
 // OneForOne is an Strategy that tells the Supervisor to only restart the
 // child process that errored
+//
+// Since: 0.0.0
 var OneForOne = s.OneForOne
 
 // CleanupResourcesFn is a function that cleans up resources that were
 // allocated in a BuildNodesFn function.
 //
 // Check the documentation of NewSupervisorSpec for more details and examples
+//
+// Since: 0.0.0
 type CleanupResourcesFn = s.CleanupResourcesFn
 
 // BuildNodesFn is a function that returns a list of nodes
 //
 // Check the documentation of NewSupervisorSpec for more details and examples.
+//
+// Since: 0.0.0
 type BuildNodesFn = s.BuildNodesFn
 
 // SupervisorSpec represents the specification of a static supervisor; it serves
@@ -48,6 +64,8 @@ type BuildNodesFn = s.BuildNodesFn
 //
 // * Notifies the supervisor to restart a child node (and, if specified all its
 // siblings as well) when the node fails in unexpected ways.
+//
+// Since: 0.0.0
 type SupervisorSpec = s.SupervisorSpec
 
 // NewSupervisorSpec creates a SupervisorSpec. It requires the name of the
@@ -150,9 +168,12 @@ type SupervisorSpec = s.SupervisorSpec
 // of the API to implement start timeouts and cleanup timeouts inside the given
 // BuildNodesFn and CleanupResourcesFn functions.
 //
+// Since: 0.0.0
 var NewSupervisorSpec = s.NewSupervisorSpec
 
 // Opt is a type used to configure a SupervisorSpec
+//
+// Since: 0.0.0
 type Opt = s.Opt
 
 // WithStartOrder is an Opt that specifies the start/stop order of a supervisor's
@@ -166,6 +187,8 @@ type Opt = s.Opt
 // * RightToLeft -- Start children nodes from right to left, stop them from left
 // to right
 //
+//
+// Since: 0.0.0
 var WithStartOrder = s.WithStartOrder
 
 // WithOrder is a backwards compatible alias to WithStartOrder
@@ -186,6 +209,7 @@ var WithOrder = WithStartOrder
 // [*] This option may come handy when all the other siblings depend on one another
 // to work correctly.
 //
+// Since: 0.0.0
 var WithStrategy = s.WithStrategy
 
 // WithNotifier is an Opt that specifies a callback that gets called whenever
@@ -195,6 +219,7 @@ var WithStrategy = s.WithStrategy
 // the systems, and it is a great place to hook in monitoring services like
 // logging, error tracing and metrics gatherers
 //
+// Since: 0.0.0
 var WithNotifier = s.WithNotifier
 
 // WithNodes allows the registration of child nodes in a SupervisorSpec. Node
@@ -219,6 +244,7 @@ var WithNodes = s.WithNodes
 //   //
 //   WithRestartTolerance(10, 5 * time.Second)
 //
+// Since: 0.1.0
 var WithRestartTolerance = s.WithRestartTolerance
 
 // Subtree transforms SupervisorSpec into a Node. This function allows you to
@@ -244,9 +270,12 @@ var WithRestartTolerance = s.WithRestartTolerance
 //    ),
 //   )
 //
+// Since: 0.0.0
 var Subtree = s.Subtree
 
 // DynSupervisor is a supervisor that can spawn workers in a procedural way.
+//
+// Since: 0.0.0
 type DynSupervisor = s.DynSupervisor
 
 // NewDynSupervisor creates a DynamicSupervisor which can start workers at
@@ -271,6 +300,7 @@ type DynSupervisor = s.DynSupervisor
 // * In case of a hard crash and following restart, it will start with an empty
 //   list of children
 //
+// Since: 0.0.0
 var NewDynSupervisor = s.NewDynSupervisor
 
 // Supervisor represents the root of a tree of goroutines. A Supervisor may have
@@ -278,4 +308,6 @@ var NewDynSupervisor = s.NewDynSupervisor
 // goroutine that gets automatic restart abilities as soon as the parent
 // supervisor detects an error has occured. A Supervisor will always be
 // generated from a SupervisorSpec
+//
+// Since: 0.0.0
 type Supervisor = s.Supervisor

--- a/cap/supervisor_exports.go
+++ b/cap/supervisor_exports.go
@@ -1,0 +1,281 @@
+package cap
+
+import (
+	"github.com/capatazlib/go-capataz/internal/s"
+)
+
+// Node represents a tree node in a supervision tree, it could either be a
+// Subtree or a Worker
+type Node = s.Node
+
+// Order specifies the order in which a supervisor is going to start its node
+// children. The stop order is the reverse of the start order.
+type Order = s.Order
+
+// LeftToRight is an Order that specifies children start from left to right
+var LeftToRight = s.LeftToRight
+
+// RightToLeft is an Order that specifies children start from right to left
+var RightToLeft = s.RightToLeft
+
+// Strategy specifies how children get restarted when one of them reports an
+// error
+type Strategy = s.Strategy
+
+// OneForOne is an Strategy that tells the Supervisor to only restart the
+// child process that errored
+var OneForOne = s.OneForOne
+
+// CleanupResourcesFn is a function that cleans up resources that were
+// allocated in a BuildNodesFn function.
+//
+// Check the documentation of NewSupervisorSpec for more details and examples
+type CleanupResourcesFn = s.CleanupResourcesFn
+
+// BuildNodesFn is a function that returns a list of nodes
+//
+// Check the documentation of NewSupervisorSpec for more details and examples.
+type BuildNodesFn = s.BuildNodesFn
+
+// SupervisorSpec represents the specification of a static supervisor; it serves
+// as a template for the construction of a runtime supervision tree. In the
+// SupervisorSpec you can specify settings like:
+//
+// * The children (workers or sub-trees) you want spawned in your system when it
+// starts
+//
+// * The order in which the supervised node children get started
+//
+// * Notifies the supervisor to restart a child node (and, if specified all its
+// siblings as well) when the node fails in unexpected ways.
+type SupervisorSpec = s.SupervisorSpec
+
+// NewSupervisorSpec creates a SupervisorSpec. It requires the name of the
+// supervisor (for tracing purposes) and some children nodes to supervise.
+//
+// Monitoring children that do not share resources
+//
+// This is intended for situations where you need worker goroutines that are
+// self-contained running in the background.
+//
+// To specify a group of children nodes, you need to use the WithNodes utility
+// function. This function may receive Subtree or Worker nodes.
+//
+// Example:
+//
+//     cap.NewSupervisorSpec("root",
+//
+//       // (1)
+//       // Specify child nodes to spawn when this supervisor starts
+//       cap.WithNodes(
+//         cap.Subtree(subtreeSupervisorSpec),
+//         workerChildSpec,
+//       ),
+//
+//       // (2)
+//       // Specify child nodes start from right to left (reversed order) and
+//       // stop from left to right.
+//       cap.WithStartOrder(cap.RightToLeft),
+//     )
+//
+//
+// Monitoring nodes that share resources
+//
+// Sometimes, you want a group of children nodes to interact between each other
+// via some shared resource that only the workers know about (for example, a
+// gochan, a db datapool, etc).
+//
+// You are able to specify a custom function (BuildNodesFn) that allocates and
+// releases these resources.
+//
+// This function should return:
+//
+// * The children nodes of the supervision tree
+//
+// * A function that cleans up the allocated resources (CleanupResourcesFn)
+//
+// * An error, but only in the scenario where a resource initialization failed
+//
+// Example:
+//
+//     cap.NewSupervisorSpec("root",
+//
+//       // (1)
+//       // Implement a function that return all nodes to be supervised.
+//       // When this supervisor gets (re)started, this function will be called.
+//       // Imagine this function as a factory for it's children.
+//       func() ([]cap.Node, cap.CleanupResourcesFn, error) {
+//
+//         // In this example, child nodes have a shared resource (a gochan)
+//         // and it gets passed to their constructors.
+//         buffer := make(chan MyType)
+//         nodes := []cap.Node{
+//           producerWorker(buffer),
+//           consumerWorker(buffer),
+//         }
+//
+//         // We create a function that gets executed when the supervisor
+//         // shuts down.
+//         cleanup := func() {
+//           close(buffer)
+//         }
+//
+//         // We return the allocated Node records and the cleanup function
+//         return nodes, cleanup, nil
+//       },
+//
+//       // (2)
+//       cap.WithStartOrder(cap.RightToLeft),
+//     )
+//
+// Dealing with errors
+//
+// Given resources can involve IO allocations, using this functionality opens
+// the door to a few error scenarios:
+//
+// 1) Resource allocation returns an error
+//
+// In this scenario, the supervision start procedure will fail and it will
+// follow the regular shutdown procedure: the already started nodes will be
+// terminated and an error will be returned immediately.
+//
+// 2) Resource cleanup returns an error
+//
+// In this scenario, the termination procedure will collect the error and report
+// it in the returned SupervisorError.
+//
+// 3) Resource allocation/cleanup hangs
+//
+// This library does not handle this scenario. Is the responsibility of the user
+// of the API to implement start timeouts and cleanup timeouts inside the given
+// BuildNodesFn and CleanupResourcesFn functions.
+//
+var NewSupervisorSpec = s.NewSupervisorSpec
+
+// Opt is a type used to configure a SupervisorSpec
+type Opt = s.Opt
+
+// WithStartOrder is an Opt that specifies the start/stop order of a supervisor's
+// children nodes
+//
+// Possible values may be:
+//
+// * LeftToRight -- Start children nodes from left to right, stop them from
+// right to left
+//
+// * RightToLeft -- Start children nodes from right to left, stop them from left
+// to right
+//
+var WithStartOrder = s.WithStartOrder
+
+// WithOrder is a backwards compatible alias to WithStartOrder
+//
+// Deprecated: Use WithStartOrder instead
+var WithOrder = WithStartOrder
+
+// WithStrategy is an Opt that specifies how children nodes of a supervisor get
+// restarted when one of the nodes fails
+//
+// Possible values may be:
+//
+// * OneForOne -- Only restart the failing child
+//
+// * OneForAll (Not Implemented Yet) -- Restart the failing child and all its
+// siblings[*]
+//
+// [*] This option may come handy when all the other siblings depend on one another
+// to work correctly.
+//
+var WithStrategy = s.WithStrategy
+
+// WithNotifier is an Opt that specifies a callback that gets called whenever
+// the supervision system reports an Event
+//
+// This function may be used to observe the behavior of all the supervisors in
+// the systems, and it is a great place to hook in monitoring services like
+// logging, error tracing and metrics gatherers
+//
+var WithNotifier = s.WithNotifier
+
+// WithNodes allows the registration of child nodes in a SupervisorSpec. Node
+// records passed to this function are going to be supervised by the Supervisor
+// created from a SupervisorSpec.
+//
+// Check the documentation of NewSupervisorSpec for more details and examples.
+var WithNodes = s.WithNodes
+
+// WithRestartTolerance is a Opt that specifies how many errors the supervisor
+// should be willing to tolerate before giving up restarting and fail.
+//
+// If the tolerance is met, the supervisor is going to fail, if this is a
+// sub-tree, this error is going to be handled by a grand-parent supervisor,
+// restarting the tolerance again.
+//
+// Example
+//
+//   // Tolerate 10 errors every 5 seconds
+//   //
+//   // - if there is 11 errors in a 5 second window, it makes the supervisor fail
+//   //
+//   WithRestartTolerance(10, 5 * time.Second)
+//
+var WithRestartTolerance = s.WithRestartTolerance
+
+// Subtree transforms SupervisorSpec into a Node. This function allows you to
+// insert a black-box sub-system into a bigger supervised system.
+//
+// Note the subtree SupervisorSpec is going to inherit the event notifier from
+// its parent supervisor.
+//
+// Example:
+//
+//   // Initialized a SupervisorSpec that doesn't know anything about other
+//   // parts of the systems (e.g. is self-contained)
+//   networkingSubsystem := cap.NewSupervisorSpec("net", ...)
+//
+//   // Another self-contained system
+//   filesystemSubsystem := cap.NewSupervisorSpec("fs", ...)
+//
+//   // SupervisorSpec that is started in your main.go
+//   cap.NewSupervisorSpec("root",
+//    cap.WithNodes(
+//      cap.Subtree(networkingSubsystem),
+//      cap.Subtree(filesystemSubsystem),
+//    ),
+//   )
+//
+var Subtree = s.Subtree
+
+// DynSupervisor is a supervisor that can spawn workers in a procedural way.
+type DynSupervisor = s.DynSupervisor
+
+// NewDynSupervisor creates a DynamicSupervisor which can start workers at
+// runtime in a procedural manner. It receives a context and the supervisor name
+// (for tracing purposes).
+//
+//
+// When to use a DynSupervisor?
+//
+// If you want to run supervised worker routines on dynamic inputs. This is
+// something that a regular Supervisor cannot do, as it needs to know the
+// children nodes at construction time.
+//
+// Differences to Supervisor
+//
+// As opposed to a Supervisor, a DynSupervisor:
+//
+// * Cannot receive node specifications to start them in an static fashion
+//
+// * It is able to spawn workers dynamically
+//
+// * In case of a hard crash and following restart, it will start with an empty
+//   list of children
+//
+var NewDynSupervisor = s.NewDynSupervisor
+
+// Supervisor represents the root of a tree of goroutines. A Supervisor may have
+// leaf or sub-tree children, where each of the nodes in the tree represent a
+// goroutine that gets automatic restart abilities as soon as the parent
+// supervisor detects an error has occured. A Supervisor will always be
+// generated from a SupervisorSpec
+type Supervisor = s.Supervisor

--- a/cap/worker_exports.go
+++ b/cap/worker_exports.go
@@ -6,12 +6,16 @@ import (
 )
 
 // Restart specifies when a goroutine gets restarted
+//
+// Since: 0.0.0
 type Restart = c.Restart
 
 // Permanent specifies that a goroutine should be restarted whether or not there
 // are errors.
 //
 // You can specify this option using the WithRestart function
+//
+// Since: 0.0.0
 var Permanent = c.Permanent
 
 // Transient specifies that a goroutine should be restarted if and only if the
@@ -19,22 +23,29 @@ var Permanent = c.Permanent
 // is not restarted again.
 //
 // You can specify this option using the WithRestart function
+//
+// Since: 0.0.0
 var Transient = c.Transient
 
 // Temporary specifies that the goroutine should not be restarted under any
 // circumstances
 //
 // You can specify this option using the WithRestart function
+//
+// Since: 0.0.0
 var Temporary = c.Temporary
 
 // Shutdown is an enum type that indicates how the parent supervisor will handle
 // the stoppping of the worker goroutine
 //
+// Since: 0.0.0
 type Shutdown = c.Shutdown
 
 // Indefinitely is a Shutdown value that specifies the parent supervisor must
 // wait indefinitely for the worker goroutine to stop executing. You can specify
 // this option using the WithShutdown function
+//
+// Since: 0.0.0
 var Indefinitely = c.Indefinitely
 
 // Timeout is a Shutdown function that returns a value that indicates the time
@@ -54,21 +65,31 @@ var Indefinitely = c.Indefinitely
 // goroutine is not using the offered context value), the supervisor will
 // continue with the shutdown procedure (reporting a shutdown error), possibly
 // leaving the goroutine running in memory (e.g. memory leak)
+//
+// Since: 0.0.0
 var Timeout = c.Timeout
 
 // NodeTag specifies the type of node that is running. This is a closed set
 // given we will only support workers and supervisors
+//
+// Since: 0.0.0
 type NodeTag = c.ChildTag
 
 // WorkerT is a NodeTag used to indicate a goroutine is a worker that run some
 // business-logic
+//
+// Since: 0.0.0
 var WorkerT = c.Worker
 
 // SupervisorT is a NodeTag used to indicate a goroutine is running another
 // supervision tree
+//
+// Since: 0.0.0
 var SupervisorT = c.Supervisor
 
 // WorkerOpt is used to configure a Worker node spec
+//
+// Since: 0.0.0
 type WorkerOpt = c.Opt
 
 // WithRestart is a WorkerOpt that specifies how the parent supervisor should
@@ -82,6 +103,7 @@ type WorkerOpt = c.Opt
 //
 // * Temporary -- Never restart a worker goroutine (go keyword behavior)
 //
+// Since: 0.0.0
 var WithRestart = c.WithRestart
 
 // WithShutdown is a WorkerOpt that specifies how the shutdown of the worker is
@@ -95,25 +117,34 @@ var WithRestart = c.WithRestart
 // * Timeout(time.Duration) -- Wait for a duration of time before giving up
 // shuting down this worker goroutine
 //
+// Since: 0.0.0
 var WithShutdown = c.WithShutdown
 
 // WithCapturePanic is a WorkerOpt that specifies if panics raised by
 // this worker should be treated as errors.
+//
+// Since: 0.0.0
 var WithCapturePanic = c.WithCapturePanic
 
 // WithTag is a WorkerOpt that sets the given NodeTag on Worker.
 //
 // Do not use this function if you are not extending capataz' API.
+//
+// Since: 0.0.0
 var WithTag = c.WithTag
 
 // WithTolerance is a WorkerOpt that specifies how many errors the supervisor
 // should be willing to tolerate before giving up restarting and fail.
 //
 // Deprecated: Use WithRestartTolerance instead.
+//
+// Since: 0.0.0
 var WithTolerance = c.WithTolerance
 
 // GetWorkerName returns the runtime name of a supervised goroutine by plucking it
 // up from the given context.
+//
+// Since: 0.0.0
 var GetWorkerName = c.GetNodeName
 
 // NotifyStartFn is a function given to worker nodes that allows them to notify
@@ -122,6 +153,8 @@ var GetWorkerName = c.GetNodeName
 // The argument contains an error if there was a failure, nil otherwise.
 //
 // See the documentation of NewWorkerWithNotifyStart for more details
+//
+// Since: 0.0.0
 type NotifyStartFn = c.NotifyStartFn
 
 // NewWorker creates a Node that represents a worker goroutine. It requires two
@@ -173,4 +206,5 @@ var NewWorker = s.NewWorker
 // NotifyStartFn function with the impending error as a parameter. This will
 // cause the whole supervision system start procedure to abort.
 //
+// Since: 0.0.0
 var NewWorkerWithNotifyStart = s.NewWorkerWithNotifyStart

--- a/cap/worker_exports.go
+++ b/cap/worker_exports.go
@@ -2,6 +2,7 @@ package cap
 
 import (
 	"github.com/capatazlib/go-capataz/internal/c"
+	"github.com/capatazlib/go-capataz/internal/s"
 )
 
 // Restart specifies when a goroutine gets restarted
@@ -114,3 +115,62 @@ var WithTolerance = c.WithTolerance
 // GetWorkerName returns the runtime name of a supervised goroutine by plucking it
 // up from the given context.
 var GetWorkerName = c.GetNodeName
+
+// NotifyStartFn is a function given to worker nodes that allows them to notify
+// the parent supervisor that they are officialy started.
+//
+// The argument contains an error if there was a failure, nil otherwise.
+//
+// See the documentation of NewWorkerWithNotifyStart for more details
+type NotifyStartFn = c.NotifyStartFn
+
+// NewWorker creates a Node that represents a worker goroutine. It requires two
+// arguments: a name that is used for runtime tracing and a startFn function.
+//
+// The name argument
+//
+// A name argument must not be empty nor contain forward slash characters (e.g.
+// /), otherwise, the system will panic[*].
+//
+// [*] This method is preferred as opposed to return an error given it is considered
+// a bad implementation (ideally a compilation error).
+//
+// The startFn argument
+//
+// The startFn function is where your business logic should be located. This
+// function will be running on a new supervised goroutine.
+//
+// The startFn function will receive a context.Context record that *must* be
+// used inside your business logic to accept stop signals from its parent
+// supervisor.
+//
+// Depending on the Shutdown values used with the WithShutdown settings of the
+// worker, if the `startFn` function does not respect the given context, the
+// parent supervisor will either block forever or leak goroutines after a
+// timeout has been reached.
+//
+var NewWorker = s.NewWorker
+
+// NewWorkerWithNotifyStart accomplishes the same goal as NewWorker with the
+// addition of passing an extra argument (notifyStart callback) to the startFn
+// function parameter.
+//
+// The NotifyStartFn argument
+//
+// Sometimes you want to consider a goroutine started after certain
+// initialization was done; like doing a read from a Database or API, or some
+// socket is bound, etc. The NotifyStartFn is a callback that allows the spawned
+// worker goroutine to signal when it has officially started.
+//
+// It is essential to call this callback function in your business logic as soon
+// as you consider the worker is initialized, otherwise the parent supervisor
+// will block and eventually fail with a timeout.
+//
+// Report a start error on NotifyStartFn
+//
+// If for some reason, a child node is not able to start correctly (e.g. DB
+// connection fails, network is kaput), the node may call the given
+// NotifyStartFn function with the impending error as a parameter. This will
+// cause the whole supervision system start procedure to abort.
+//
+var NewWorkerWithNotifyStart = s.NewWorkerWithNotifyStart

--- a/internal/s/dyn_supervisor.go
+++ b/internal/s/dyn_supervisor.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"context"

--- a/internal/s/error.go
+++ b/internal/s/error.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"errors"

--- a/internal/s/event.go
+++ b/internal/s/event.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"fmt"
@@ -51,7 +51,7 @@ func (tag EventTag) String() string {
 // supervision system.
 type Event struct {
 	tag                EventTag
-	nodeTag            NodeTag
+	nodeTag            c.ChildTag
 	processRuntimeName string
 	err                error
 	created            time.Time
@@ -63,8 +63,8 @@ func (e Event) GetTag() EventTag {
 	return e.tag
 }
 
-// GetNodeTag returns the NodeTag from an Event
-func (e Event) GetNodeTag() NodeTag {
+// GetNodeTag returns the c.ChildTag from an Event
+func (e Event) GetNodeTag() c.ChildTag {
 	return e.nodeTag
 }
 
@@ -106,7 +106,7 @@ type EventNotifier func(Event)
 
 // processTerminated reports an event with an EventTag of ProcessTerminated
 func (en EventNotifier) processTerminated(
-	nodeTag NodeTag,
+	nodeTag c.ChildTag,
 	name string,
 	stopTime time.Time,
 ) {
@@ -139,7 +139,7 @@ func (en EventNotifier) workerCompleted(name string) {
 
 // processFailed reports an event with an EventTag of ProcessFailed
 func (en EventNotifier) processFailed(
-	nodeTag NodeTag,
+	nodeTag c.ChildTag,
 	name string,
 	err error,
 ) {
@@ -169,7 +169,7 @@ func (en EventNotifier) workerFailed(name string, err error) {
 
 // processStartFailed reports an event with an EventTag of ProcessStartFailed
 func (en EventNotifier) processStartFailed(
-	nodeTag NodeTag,
+	nodeTag c.ChildTag,
 	name string,
 	err error,
 ) {
@@ -191,7 +191,7 @@ func (en EventNotifier) supervisorStartFailed(name string, err error) {
 //	en.processStartFailed(c.Worker, name, err)
 // }
 
-func processStarted(en EventNotifier, nodeTag NodeTag, name string, startTime time.Time) {
+func processStarted(en EventNotifier, nodeTag c.ChildTag, name string, startTime time.Time) {
 	createdTime := time.Now()
 	startDuration := createdTime.Sub(startTime)
 	en(Event{

--- a/internal/s/healthcheck.go
+++ b/internal/s/healthcheck.go
@@ -48,6 +48,7 @@ func (hr HealthReport) IsHealthyReport() bool {
 //                            an unhealthy environment. Any process that fails
 //                            to restart under the threshold results in an
 //                            unhealthy report
+//
 func NewHealthcheckMonitor(
 	maxAllowedFailures uint32,
 	maxAllowedRestartDuration time.Duration,

--- a/internal/s/healthcheck.go
+++ b/internal/s/healthcheck.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"sync"
@@ -40,9 +40,11 @@ func (hr HealthReport) IsHealthyReport() bool {
 
 // NewHealthcheckMonitor offers a way to monitor a supervision tree health from
 // events emitted by it.
-// MaxAllowedFailures: the threshold beyond which the environment is considered
+//
+// maxAllowedFailures: the threshold beyond which the environment is considered
 //                     unhealthy.
-// MaxAllowedRestartDuration: the restart threshold, which if exceeded, indicates
+//
+// maxAllowedRestartDuration: the restart threshold, which if exceeded, indicates
 //                            an unhealthy environment. Any process that fails
 //                            to restart under the threshold results in an
 //                            unhealthy report

--- a/internal/s/healthcheck_internal_test.go
+++ b/internal/s/healthcheck_internal_test.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"errors"

--- a/internal/s/monitor.go
+++ b/internal/s/monitor.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"context"

--- a/internal/s/one_for_one.go
+++ b/internal/s/one_for_one.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"context"

--- a/internal/s/restart_tolerance.go
+++ b/internal/s/restart_tolerance.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"time"

--- a/internal/s/restart_tolerance_internal_test.go
+++ b/internal/s/restart_tolerance_internal_test.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"testing"

--- a/internal/s/root.go
+++ b/internal/s/root.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 // This file contains the implementation of the supervision start
 //

--- a/internal/s/spec.go
+++ b/internal/s/spec.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"context"

--- a/internal/s/subtree.go
+++ b/internal/s/subtree.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 // This file contains logic on supervision sub-trees
 
@@ -131,7 +131,7 @@ func (spec SupervisorSpec) subtree(
 //    ),
 //   )
 //
-func Subtree(subtreeSpec SupervisorSpec, opts ...WorkerOpt) Node {
+func Subtree(subtreeSpec SupervisorSpec, opts ...c.Opt) Node {
 	return func(supSpec SupervisorSpec) c.ChildSpec {
 		return supSpec.subtree(subtreeSpec, opts...)
 	}

--- a/internal/s/supervisor.go
+++ b/internal/s/supervisor.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 // This file contains the implementation of the public methods for the
 // Supervisor API

--- a/internal/s/supervisor_options.go
+++ b/internal/s/supervisor_options.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"time"

--- a/internal/s/worker.go
+++ b/internal/s/worker.go
@@ -1,4 +1,4 @@
-package cap
+package s
 
 import (
 	"context"
@@ -46,7 +46,7 @@ func childToNode(chSpec c.ChildSpec) Node {
 // parent supervisor will either block forever or leak goroutines after a
 // timeout has been reached.
 //
-func NewWorker(name string, startFn func(context.Context) error, opts ...WorkerOpt) Node {
+func NewWorker(name string, startFn func(context.Context) error, opts ...c.Opt) Node {
 	return childToNode(c.New(name, startFn, opts...))
 }
 
@@ -75,7 +75,7 @@ func NewWorker(name string, startFn func(context.Context) error, opts ...WorkerO
 func NewWorkerWithNotifyStart(
 	name string,
 	startFn func(context.Context, NotifyStartFn) error,
-	opts ...WorkerOpt,
+	opts ...c.Opt,
 ) Node {
 	return childToNode(c.NewWithNotifyStart(name, startFn, opts...))
 }


### PR DESCRIPTION
### Context

As a way to ensure we don't accidentally export new public symbols to the `go-capataz` API, I'm moving all files with business logic to `internal/s`, and *explicitly* exporting the symbols the public API wants to provide via `var` and `type` aliasing.

This PR is not adding new logic. It only moves codes from one place to another and adds explicit export lists inside the files of the `cap` package