### PR TITLE
Add ReliableNotifier API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 * Move all files in the `cap` folder to `internal/s` and do an explicit export
   list of symbols (#56)
 
+* Add a new `EventNotifier` called `ReliableNotifier`, which guarantees a safe,
+  failure tolerant, latency tolerant event notifier dispatching mechanism. (#58)
+
+* Expose the `NodeSepToken` variable to join symbols from a tree hierarchy. (#58)
+
 # v0.0.0
 
 * See changes on [Every PR](https://github.com/capatazlib/go-capataz/pulls?q=is%3Apr+is%3Aclosed+label%3Apre-changelog) that was created before a CHANGELOG file was added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 * Expose the `NodeSepToken` variable to join symbols from a tree hierarchy. (#58)
 
+* Add new `EventCriteria` combinator which allows us to easily modify
+  `EventNotifier` values to accept a subset of events (#58)
+
 # v0.0.0
 
 * See changes on [Every PR](https://github.com/capatazlib/go-capataz/pulls?q=is%3Apr+is%3Aclosed+label%3Apre-changelog) that was created before a CHANGELOG file was added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@
 * Add a new `EventNotifier` called `ReliableNotifier`, which guarantees a safe,
   failure tolerant, latency tolerant event notifier dispatching mechanism. (#58)
 
-* Expose the `NodeSepToken` variable to join symbols from a tree hierarchy. (#58)
+* Expose the `NodeSepToken` variable to join symbols from a tree hierarchy.
+  (#58)
 
 * Add new `EventCriteria` combinator which allows us to easily modify
   `EventNotifier` values to accept a subset of events (#58)
 
 # v0.0.0
 
-* See changes on [Every PR](https://github.com/capatazlib/go-capataz/pulls?q=is%3Apr+is%3Aclosed+label%3Apre-changelog) that was created before a CHANGELOG file was added
+* See changes on [Every
+  PR](https://github.com/capatazlib/go-capataz/pulls?q=is%3Apr+is%3Aclosed+label%3Apre-changelog)
+  that was created before a CHANGELOG file was added

--- a/cap/event_exports.go
+++ b/cap/event_exports.go
@@ -1,6 +1,9 @@
 package cap
 
-import "github.com/capatazlib/go-capataz/internal/s"
+import (
+	"github.com/capatazlib/go-capataz/internal/n"
+	"github.com/capatazlib/go-capataz/internal/s"
+)
 
 // EventTag specifies the type of Event that gets notified from the supervision
 // system
@@ -48,3 +51,34 @@ type Event = s.Event
 //
 // Since: 0.0.0
 type EventNotifier = s.EventNotifier
+
+// ReliableNotifierOpt allows clients to tweak the behavior of an EventNotifier
+// instance built with NewReliableNotifier
+//
+// Since: 0.1.0
+type ReliableNotifierOpt = n.ReliableNotifierOpt
+
+// NewReliableNotifier is an EventNotifier that guarantees it will never panic
+// the execution of its caller, and that it will continue sending events to
+// notifiers despite previous panics
+//
+// Since: 0.1.0
+var NewReliableNotifier = n.NewReliableNotifier
+
+// WithOnNotifierTimeout sets callback that gets executed when a given notifier drops
+// an event because it cannot process it.
+//
+// Since: 0.1.0
+var WithOnNotifierTimeout = n.WithOnNotifierTimeout
+
+// WithNotifierTimeout sets the maximum allowed time the reliable notifier is going to
+// wait for a notifier function to be ready to receive an event (defaults to 10 millis).
+//
+// since: 0.1.0
+var WithNotifierTimeout = n.WithNotifierTimeout
+
+// WithOnReliableNotifierFailure sets a callback that gets executed when a failure
+// occurs on the event broadcasting logic
+//
+// Since: 0.1.0
+var WithOnReliableNotifierFailure = n.WithOnReliableNotifierFailure

--- a/cap/event_exports.go
+++ b/cap/event_exports.go
@@ -128,6 +128,7 @@ var EIsWorkerFailure = n.EIsWorkerFailure
 var EIsSupervisorRestartError = n.EIsSupervisorRestartError
 
 // EHasName returns true if the runtime name of the node that emitted the event
+// matches the given name
 //
 // Since: 0.1.0
 var EHasName = n.EHasName

--- a/cap/event_exports.go
+++ b/cap/event_exports.go
@@ -82,3 +82,56 @@ var WithNotifierTimeout = n.WithNotifierTimeout
 //
 // Since: 0.1.0
 var WithOnReliableNotifierFailure = n.WithOnReliableNotifierFailure
+
+// EventCriteria is an utility that allows us to specify a matching criteria to
+// a specific supervision event
+//
+// Since: 0.1.0
+type EventCriteria = n.EventCriteria
+
+// EAnd joins a slice of EventCriteria with an and statement
+//
+// Since: 0.1.0
+var EAnd = n.EAnd
+
+// EOr joins a slice of EventCriteria with an or statement
+//
+// Since: 0.1.0
+var EOr = n.EOr
+
+// ENot negates the result from a given EventCriteria
+//
+// Since: 0.1.0
+var ENot = n.ENot
+
+// EInSubtree allows to filter s.Event that were sent from an specific subtree
+//
+// Since: 0.1.0
+var EInSubtree = n.EInSubtree
+
+// EIsFailure returns true if the event represent a node failure
+//
+// Since: 0.1.0
+var EIsFailure = n.EIsFailure
+
+// EIsWorkerFailure returns true if the event represents a worker failure
+//
+// Since: 0.1.0
+var EIsWorkerFailure = n.EIsWorkerFailure
+
+// EIsSupervisorRestartError returns true if the event represents a restart
+// tolerance reached error
+//
+// Since: 0.1.0
+var EIsSupervisorRestartError = n.EIsSupervisorRestartError
+
+// EHasName returns true if the runtime name of the node that emitted the event
+//
+// Since: 0.1.0
+var EHasName = n.EHasName
+
+// SelectEventByCriteria forwards Event records that match positively the given
+// criteria to the given EventNotifier
+//
+// Since: 0.1.0
+var SelectEventByCriteria = n.SelectEventByCriteria

--- a/cap/event_exports.go
+++ b/cap/event_exports.go
@@ -89,12 +89,14 @@ var WithOnReliableNotifierFailure = n.WithOnReliableNotifierFailure
 // Since: 0.1.0
 type EventCriteria = n.EventCriteria
 
-// EAnd joins a slice of EventCriteria with an and statement
+// EAnd joins a slice of EventCriteria with an "and" statement. A call without
+// arguments will accept all given events.
 //
 // Since: 0.1.0
 var EAnd = n.EAnd
 
-// EOr joins a slice of EventCriteria with an or statement
+// EOr joins a slice of EventCriteria with an "or" statement. A call without
+// arguments wil reject all given events.
 //
 // Since: 0.1.0
 var EOr = n.EOr

--- a/internal/n/crit.go
+++ b/internal/n/crit.go
@@ -12,7 +12,8 @@ import (
 // a specific supervision event
 type EventCriteria func(s.Event) bool
 
-// EAnd joins a slice of EventCriteria with an and statement
+// EAnd joins a slice of EventCriteria with an "and" statement. A call without
+// arguments will accept all given events.
 func EAnd(crits ...EventCriteria) EventCriteria {
 	return func(ev s.Event) bool {
 		result := true
@@ -26,7 +27,8 @@ func EAnd(crits ...EventCriteria) EventCriteria {
 	}
 }
 
-// EOr joins a slice of EventCriteria with an or statement
+// EOr joins a slice of EventCriteria with an "or" statement. A call without
+// arguments wil reject all given events.
 func EOr(crits ...EventCriteria) EventCriteria {
 	return func(ev s.Event) bool {
 		result := false
@@ -40,27 +42,29 @@ func EOr(crits ...EventCriteria) EventCriteria {
 	}
 }
 
-// ENot negates the result from a given EventCriteria
+// ENot negates the result from a given EventCriteria.
 func ENot(crit EventCriteria) EventCriteria {
 	return func(ev s.Event) bool {
 		return !crit(ev)
 	}
 }
 
-// EInSubtree allows to filter s.Event that were sent from an specific subtree
-func EInSubtree(names ...string) EventCriteria {
-	prefix := strings.Join(names, s.NodeSepToken)
+// EInSubtree allows to filter s.Event that were sent from an specific subtree.
+func EInSubtree(rawName string) EventCriteria {
+	// ensure internal token is not coupled to this API
+	tokens := strings.Split(rawName, "/")
+	prefix := strings.Join(tokens, s.NodeSepToken)
 	return func(ev s.Event) bool {
 		return strings.HasPrefix(ev.GetProcessRuntimeName(), prefix)
 	}
 }
 
-// EIsFailure returns true if the event represent a node failure
+// EIsFailure returns true if the event represent a node failure.
 var EIsFailure EventCriteria = func(ev s.Event) bool {
 	return ev.GetTag() == s.ProcessFailed
 }
 
-// EIsWorkerFailure returns true if the event represents a worker failure
+// EIsWorkerFailure returns true if the event represents a worker failure.
 var EIsWorkerFailure EventCriteria = func(ev s.Event) bool {
 	return EIsFailure(ev) && ev.GetNodeTag() == c.Worker
 }
@@ -76,8 +80,11 @@ var EIsSupervisorRestartError EventCriteria = func(ev s.Event) bool {
 
 // EHasName returns true if the runtime name of the node that emitted the event
 // matches the given name
-func EHasName(names ...string) EventCriteria {
-	name := strings.Join(names, s.NodeSepToken)
+func EHasName(rawName string) EventCriteria {
+	// ensure internal token is not coupled to this API
+	tokens := strings.Split(rawName, "/")
+	name := strings.Join(tokens, s.NodeSepToken)
+
 	return func(ev s.Event) bool {
 		return ev.GetProcessRuntimeName() == name
 	}

--- a/internal/n/crit.go
+++ b/internal/n/crit.go
@@ -1,0 +1,94 @@
+package n
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/capatazlib/go-capataz/internal/c"
+	"github.com/capatazlib/go-capataz/internal/s"
+)
+
+// EventCriteria is an utility that allows us to specify a matching criteria to
+// a specific supervision event
+type EventCriteria func(s.Event) bool
+
+// EAnd joins a slice of EventCriteria with an and statement
+func EAnd(crits ...EventCriteria) EventCriteria {
+	return func(ev s.Event) bool {
+		result := true
+		for _, crit := range crits {
+			result = result && crit(ev)
+			if !result {
+				return result
+			}
+		}
+		return result
+	}
+}
+
+// EOr joins a slice of EventCriteria with an or statement
+func EOr(crits ...EventCriteria) EventCriteria {
+	return func(ev s.Event) bool {
+		result := false
+		for _, crit := range crits {
+			result = result || crit(ev)
+			if result {
+				return result
+			}
+		}
+		return result
+	}
+}
+
+// ENot negates the result from a given EventCriteria
+func ENot(crit EventCriteria) EventCriteria {
+	return func(ev s.Event) bool {
+		return !crit(ev)
+	}
+}
+
+// EInSubtree allows to filter s.Event that were sent from an specific subtree
+func EInSubtree(names ...string) EventCriteria {
+	prefix := strings.Join(names, s.NodeSepToken)
+	return func(ev s.Event) bool {
+		return strings.HasPrefix(ev.GetProcessRuntimeName(), prefix)
+	}
+}
+
+// EIsFailure returns true if the event represent a node failure
+var EIsFailure EventCriteria = func(ev s.Event) bool {
+	return ev.GetTag() == s.ProcessFailed
+}
+
+// EIsWorkerFailure returns true if the event represents a worker failure
+var EIsWorkerFailure EventCriteria = func(ev s.Event) bool {
+	return EIsFailure(ev) && ev.GetNodeTag() == c.Worker
+}
+
+// EIsSupervisorRestartError returns true if the event represents a restart
+// tolerance reached error
+var EIsSupervisorRestartError EventCriteria = func(ev s.Event) bool {
+	if ev.GetTag() == s.ProcessFailed && ev.GetNodeTag() == c.Supervisor {
+		return errors.Is(ev.Err(), &s.SupervisorRestartError{})
+	}
+	return false
+}
+
+// EHasName returns true if the runtime name of the node that emitted the event
+// matches the given name
+func EHasName(names ...string) EventCriteria {
+	name := strings.Join(names, s.NodeSepToken)
+	return func(ev s.Event) bool {
+		return ev.GetProcessRuntimeName() == name
+	}
+}
+
+// SelectEventByCriteria forwards Event records that match positively the given
+// criteria to the given EventNotifier
+func SelectEventByCriteria(crit EventCriteria, notifier s.EventNotifier) s.EventNotifier {
+	return func(ev s.Event) {
+		if crit(ev) {
+			notifier(ev)
+		}
+	}
+}

--- a/internal/n/crit_test.go
+++ b/internal/n/crit_test.go
@@ -92,7 +92,7 @@ func TestEInSubtree(t *testing.T) {
 	b0n := "branch0"
 	b1n := "branch1"
 
-	evNotifier := n.SelectEventByCriteria(n.EInSubtree(rootName, b0n), evNotifier0)
+	evNotifier := n.SelectEventByCriteria(n.EInSubtree("root/branch0"), evNotifier0)
 
 	b0 := s.NewSupervisorSpec(b0n, s.WithNodes(WaitDoneWorker("child0")))
 	b1 := s.NewSupervisorSpec(b1n, s.WithNodes(WaitDoneWorker("child1")))

--- a/internal/n/crit_test.go
+++ b/internal/n/crit_test.go
@@ -1,0 +1,190 @@
+package n_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/cap"
+	. "github.com/capatazlib/go-capataz/internal/stest"
+
+	"github.com/capatazlib/go-capataz/internal/n"
+	"github.com/capatazlib/go-capataz/internal/s"
+)
+
+var alwaysTrue n.EventCriteria = func(s.Event) bool { return true }
+var alwaysFalse n.EventCriteria = func(s.Event) bool { return false }
+
+func TestEAnd(t *testing.T) {
+	t.Run("all values are true", func(t *testing.T) {
+		counter := 0
+		evNotifier0 := func(s.Event) {
+			counter++
+		}
+		crit := n.EAnd(alwaysTrue, alwaysTrue, alwaysTrue)
+		evNotifier := n.SelectEventByCriteria(crit, evNotifier0)
+		evNotifier(s.Event{})
+		assert.Equal(t, 1, counter)
+	})
+
+	t.Run("one value is false", func(t *testing.T) {
+		counter := 0
+		evNotifier0 := func(s.Event) {
+			counter++
+		}
+		crit := n.EAnd(alwaysTrue, alwaysFalse, alwaysTrue)
+		evNotifier := n.SelectEventByCriteria(crit, evNotifier0)
+		evNotifier(s.Event{})
+		assert.Equal(t, 0, counter)
+	})
+}
+
+func TestEOr(t *testing.T) {
+	t.Run("all values are false", func(t *testing.T) {
+		counter := 0
+		evNotifier0 := func(s.Event) {
+			counter++
+		}
+		crit := n.EOr(alwaysFalse, alwaysFalse, alwaysFalse)
+		evNotifier := n.SelectEventByCriteria(crit, evNotifier0)
+		evNotifier(s.Event{})
+		assert.Equal(t, 0, counter)
+	})
+
+	t.Run("one value is true", func(t *testing.T) {
+		counter := 0
+		evNotifier0 := func(s.Event) {
+			counter++
+		}
+		crit := n.EOr(alwaysFalse, alwaysTrue, alwaysFalse)
+		evNotifier := n.SelectEventByCriteria(crit, evNotifier0)
+		evNotifier(s.Event{})
+		assert.Equal(t, 1, counter)
+	})
+}
+
+func TestENot(t *testing.T) {
+	crit1 := n.ENot(alwaysTrue)
+	crit2 := n.ENot(alwaysFalse)
+
+	counter := 0
+	evNotifier0 := func(s.Event) {
+		counter++
+	}
+
+	evNotifier1 := n.SelectEventByCriteria(crit1, evNotifier0)
+	evNotifier1(s.Event{})
+	assert.Equal(t, 0, counter)
+
+	evNotifier2 := n.SelectEventByCriteria(crit2, evNotifier0)
+	evNotifier2(s.Event{})
+	assert.Equal(t, 1, counter)
+}
+
+func TestEInSubtree(t *testing.T) {
+	counter := 0
+	evNotifier0 := func(s.Event) {
+		counter++
+	}
+
+	rootName := "root"
+	b0n := "branch0"
+	b1n := "branch1"
+
+	evNotifier := n.SelectEventByCriteria(n.EInSubtree(rootName, b0n), evNotifier0)
+
+	b0 := s.NewSupervisorSpec(b0n, s.WithNodes(WaitDoneWorker("child0")))
+	b1 := s.NewSupervisorSpec(b1n, s.WithNodes(WaitDoneWorker("child1")))
+
+	events, err := ObserveSupervisorWithNotifiers(
+		context.TODO(),
+		rootName,
+		s.WithNodes(
+			s.Subtree(b0),
+			s.Subtree(b1),
+		),
+		[]s.Opt{},
+		[]s.EventNotifier{evNotifier},
+		func(EventManager) {},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// 1
+			WorkerStarted("root/branch0/child0"),
+			// 2
+			SupervisorStarted("root/branch0"),
+			WorkerStarted("root/branch1/child1"),
+			SupervisorStarted("root/branch1"),
+			SupervisorStarted("root"),
+			WorkerTerminated("root/branch1/child1"),
+			SupervisorTerminated("root/branch1"),
+			// 3
+			WorkerTerminated("root/branch0/child0"),
+			// 4
+			SupervisorTerminated("root/branch0"),
+			SupervisorTerminated("root"),
+		},
+	)
+
+	assert.Equal(t, 4, counter)
+}
+
+func TestEIsFailure(t *testing.T) {
+	counter0 := 0
+	evNotifier0 := func(s.Event) {
+		counter0++
+	}
+
+	counter1 := 0
+	evNotifier1 := func(s.Event) {
+		counter1++
+	}
+
+	evNotifierA := n.SelectEventByCriteria(n.EIsFailure, evNotifier0)
+	evNotifierB := n.SelectEventByCriteria(n.EIsWorkerFailure, evNotifier1)
+
+	rootName := "root"
+	// Fail only one time
+	child1, failWorker1 := FailOnSignalWorker(1, "child1", cap.WithRestart(cap.Permanent))
+
+	events, err := ObserveSupervisorWithNotifiers(
+		context.TODO(),
+		rootName,
+		cap.WithNodes(child1),
+		[]s.Opt{},
+		[]s.EventNotifier{evNotifierA, evNotifierB},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted(rootName))
+			// 2) Start the failing behavior of child1
+			failWorker1(true /* done */)
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerStarted("root/child1"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			WorkerStarted("root/child1"),
+			SupervisorStarted("root"),
+			// A, B
+			WorkerFailed("root/child1"),
+			WorkerStarted("root/child1"),
+			WorkerTerminated("root/child1"),
+			SupervisorTerminated("root"),
+		},
+	)
+
+	assert.Equal(t, 1, counter0)
+	assert.Equal(t, 1, counter1)
+
+}

--- a/internal/n/reliable_notifier.go
+++ b/internal/n/reliable_notifier.go
@@ -1,0 +1,205 @@
+package n
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/capatazlib/go-capataz/internal/s"
+)
+
+// rootName is the name of the ReliableNotifier supervisor root tree node
+var rootName = "reliable-notifier"
+
+// notifierSettings contains settings and callbacks for a ReliableNotifier
+// instance
+type notifierSettings struct {
+	entrypointBufferSize    uint
+	notifierTimeoutDuration time.Duration
+
+	onReliableNotifierFailure func(error)
+	onNotifierTimeout         func(string)
+}
+
+// ReliableNotifierOpt allows clients to tweak the behavior of a
+// ReliableNotifier instance
+type ReliableNotifierOpt func(*notifierSettings)
+
+// newNotifierWorker runs a worker that listens to a channel dedicated to the
+// given event notifier. In the situation the notifierFn panics, the worker gets
+// restarted.
+func newNotifierWorker(
+	_ notifierSettings,
+	name string,
+	notifierFn s.EventNotifier,
+) (chan s.Event, s.Node) {
+	// ch := make(chan s.Event, settings.notifierBufferSize)
+	ch := make(chan s.Event)
+	return ch, s.NewWorker(
+		name,
+		func(ctx context.Context) error {
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case ev := <-ch:
+					notifierFn(ev)
+				}
+			}
+		},
+	)
+}
+
+// newNotifierSubTree runs a subtree of notifier workers. It restarts all
+// notifiers if one of them fails above restart threshold.
+func newNotifierSubTree(
+	settings notifierSettings,
+	notifierFns map[string]s.EventNotifier,
+) (s.Node, map[string](chan s.Event)) {
+
+	workers := make([]s.Node, 0, len(notifierFns))
+	notifierChans := make(map[string](chan s.Event))
+
+	for name, notifierFn := range notifierFns {
+		ch, worker := newNotifierWorker(settings, name, notifierFn)
+		notifierChans[name] = ch
+		workers = append(workers, worker)
+	}
+	notifierTree := s.Subtree(s.NewSupervisorSpec("notifiers", s.WithNodes(workers...)))
+
+	return notifierTree, notifierChans
+}
+
+// runEntrypointListener listens to a channel for events, and it then broadcast
+// in a non-blockin fashion the same event across multiple workers.
+func runEntrypointListener(
+	ctx context.Context,
+	settings notifierSettings,
+	entrypointCh chan s.Event,
+	notifierChans map[string](chan s.Event),
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case ev := <-entrypointCh:
+			for name, ch := range notifierChans {
+				notifyCtx, stopTimer := context.WithTimeout(
+					context.Background(),
+					settings.notifierTimeoutDuration,
+				)
+				select {
+				case <-notifyCtx.Done():
+					settings.onNotifierTimeout(name)
+
+				case ch <- ev:
+				}
+				stopTimer()
+			}
+		}
+	}
+}
+
+// WithOnNotifierTimeout sets callback that gets executed when a given notifier
+// is so slow to get an event that it gets skipped.
+func WithOnNotifierTimeout(cb func(string)) ReliableNotifierOpt {
+	return func(settings *notifierSettings) {
+		settings.onNotifierTimeout = cb
+	}
+}
+
+// WithOnReliableNotifierFailure sets a callback that gets executed when a failure
+// occurs on the event broadcasting logic
+func WithOnReliableNotifierFailure(cb func(error)) ReliableNotifierOpt {
+	return func(settings *notifierSettings) {
+		settings.onReliableNotifierFailure = cb
+	}
+}
+
+// WithNotifierTimeout sets the maximum allowed time the reliable notifier is going to
+// wait for a notifier function to be ready to receive an event (defaults to 10 millis).
+func WithNotifierTimeout(ts time.Duration) ReliableNotifierOpt {
+	return func(settings *notifierSettings) {
+		settings.notifierTimeoutDuration = ts
+	}
+}
+
+// notifyRootFailure builds an EventNotifier that executes the
+// onReliableNotifierFailure callback from the given notifierSettings
+func notifyRootFailure(settings notifierSettings) s.EventNotifier {
+	failingNode := strings.Join([]string{rootName, "notifiers"}, s.NodeSepToken)
+	return func(ev s.Event) {
+		if ev.GetTag() == s.ProcessFailed && ev.GetProcessRuntimeName() == failingNode {
+			settings.onReliableNotifierFailure(ev.Err())
+		}
+	}
+}
+
+// NewReliableNotifier is an EventNotifier that guarantees it will never panic
+// the execution of its caller, and that it will continue sending events to
+// notifiers despite previous panics
+func NewReliableNotifier(
+	notifierFns map[string]s.EventNotifier,
+	opts ...ReliableNotifierOpt,
+) (s.EventNotifier, context.CancelFunc, error) {
+
+	// default notifier settings
+	settings := notifierSettings{
+		entrypointBufferSize:      0,
+		notifierTimeoutDuration:   10 * time.Millisecond,
+		onReliableNotifierFailure: func(error) {},
+		onNotifierTimeout:         func(string) {},
+	}
+
+	for _, optFn := range opts {
+		optFn(&settings)
+	}
+
+	// the entrypoint channel is built outside the "notifier supervision tree"
+	// given the chan is referenced from the outside.
+	// entrypointCh := make(chan s.Event, settings.entrypointBufferSize)
+	entrypointCh := make(chan s.Event)
+
+	//
+	reliableNotifierSpec := s.NewSupervisorSpec(
+		rootName,
+		func() ([]s.Node, s.CleanupResourcesFn, error) {
+
+			notifierSubtree, notifierChans := newNotifierSubTree(settings, notifierFns)
+			entrypointWorker := s.NewWorker(
+				"entrypoint",
+				func(ctx context.Context) error {
+					return runEntrypointListener(ctx, settings, entrypointCh, notifierChans)
+				},
+			)
+
+			emptyCleanup := func() error { return nil }
+
+			return []s.Node{entrypointWorker, notifierSubtree}, emptyCleanup, nil
+		},
+		// we set an impossible restart tolerance, as we always want to keep
+		// this logic running (and failing in the background)
+		s.WithRestartTolerance(100, 1*time.Second),
+		s.WithNotifier(notifyRootFailure(settings)),
+		// TODO: Add OneForAll strategy here
+	)
+
+	reliableNotifier, startErr := reliableNotifierSpec.Start(context.Background())
+	if startErr != nil {
+		return nil, nil, fmt.Errorf("could not start reliable notifier: %w", startErr)
+	}
+
+	// this is the eventNotifier that the main supervision tree is going to use to
+	// send notifications.
+	eventNotifier := func(ev s.Event) {
+		entrypointCh <- ev
+	}
+
+	cancelFn := func() {
+		_ = reliableNotifier.Terminate()
+	}
+
+	return eventNotifier, cancelFn, nil
+}

--- a/internal/n/reliable_notifier_test.go
+++ b/internal/n/reliable_notifier_test.go
@@ -1,0 +1,273 @@
+// please follow the comments as close as possible and create a ticket if any
+// test does not make sense.
+package n_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/cap"
+	. "github.com/capatazlib/go-capataz/internal/stest"
+)
+
+// newBlockingNotifier creates an EventNotifier and a callback function that
+// will block until the given number of notifications have happened
+func newBlockingNotifier(total int32) (cap.EventNotifier, func()) {
+	doneCh := make(chan struct{})
+	evCount := int32(0)
+	evNotifier := func(cap.Event) {
+		current := atomic.LoadInt32(&evCount)
+		if current < total-1 {
+			atomic.AddInt32(&evCount, 1)
+			return
+		}
+		close(doneCh)
+	}
+	doneSignal := func() {
+		<-doneCh
+	}
+	return evNotifier, doneSignal
+}
+
+// newPanicBlockingNotifier creates an EventNotifier and a callback function
+// that will block until the given number of panic calls have happened
+func newPanicBlockingNotifier(total int32) (cap.EventNotifier, func()) {
+	doneCh := make(chan struct{})
+	evCount := int32(0)
+	evNotifier := func(ev cap.Event) {
+		current := atomic.LoadInt32(&evCount)
+		if current < total-1 {
+			atomic.AddInt32(&evCount, 1)
+			panic("this is taking down the tree")
+		}
+		close(doneCh)
+	}
+	doneSignal := func() {
+		<-doneCh
+	}
+	return evNotifier, doneSignal
+}
+
+func slowEvNotifier(delay time.Duration) cap.EventNotifier {
+	return func(cap.Event) {
+		time.Sleep(delay)
+	}
+}
+
+// TestReliableNotifierHappyPath checks functionality of the ReliableNotifier
+// when there are no panics on the notifiers
+func TestReliableNotifierHappyPath(t *testing.T) {
+
+	// these are the output events we are expecting from a test supervision tree
+	outEvents := []EventP{
+		WorkerStarted("root/child0"),
+		WorkerStarted("root/child1"),
+		WorkerStarted("root/child2"),
+		SupervisorStarted("root"),
+		WorkerTerminated("root/child2"),
+		WorkerTerminated("root/child1"),
+		WorkerTerminated("root/child0"),
+		SupervisorTerminated("root"),
+	}
+
+	// create multiple event notifiers with their expected number of times to be
+	// called
+	expectedCount := int32(len(outEvents))
+	notifier1, done1 := newBlockingNotifier(expectedCount)
+	notifier2, done2 := newBlockingNotifier(expectedCount)
+	notifier3, done3 := newBlockingNotifier(expectedCount)
+
+	// create the reliable event notifier that broadcasts to notifiers created in
+	// step above
+	evNotifier, cancelEvNotifier, err := cap.NewReliableNotifier(
+		map[string]cap.EventNotifier{
+			"notifier1": notifier1,
+			"notifier2": notifier2,
+			"notifier3": notifier3,
+		},
+	)
+
+	// assert reliable notifier started without errors
+	assert.NoError(t, err)
+	defer cancelEvNotifier()
+
+	// run a supervision tree such that it returns the output events declared above
+	events, err := ObserveSupervisorWithNotifiers(
+		context.TODO(),
+		"root",
+		cap.WithNodes(
+			WaitDoneWorker("child0"),
+			WaitDoneWorker("child1"),
+			WaitDoneWorker("child2"),
+		),
+		[]cap.Opt{},
+		[]cap.EventNotifier{
+			evNotifier,
+		},
+		func(EventManager) {},
+	)
+
+	// assert the events from the input supervision tree are the expected ones
+	AssertExactMatch(t, events, outEvents)
+
+	// if any of the calls bellow blocks, the test failed
+	// wait for notifier1/2/3 to receive expected event count
+	done1()
+	done2()
+	done3()
+}
+
+// TestReliableNotifierFailureCallback verifies that the failure callback gets called
+// when a given event notifier is panicking
+func TestReliableNotifierFailureCallback(t *testing.T) {
+
+	// these are the output events we are expecting from a test supervision tree
+	outEvents := []EventP{
+		WorkerStarted("root/child0"),
+		WorkerStarted("root/child1"),
+		WorkerStarted("root/child2"),
+		SupervisorStarted("root"),
+		WorkerTerminated("root/child2"),
+		WorkerTerminated("root/child1"),
+		WorkerTerminated("root/child0"),
+		SupervisorTerminated("root"),
+	}
+
+	// panicCount needs to be double the expected callback calls, given that
+	// notifier need to fail at least twice in a 5 second period to report a
+	// callback call
+	expectedCallbackCalls := int32(3)
+	panicCount := expectedCallbackCalls * 2
+
+	// create multiple event notifiers with their expected number of times to be
+	// called
+	panicEvNotifier, waitTillFailuresDone := newPanicBlockingNotifier(panicCount)
+	notifier1, done1 := newBlockingNotifier(int32(len(outEvents)))
+	notifier2, done2 := newBlockingNotifier(int32(len(outEvents)))
+
+	// build a callback function for event notifier errors
+	callbackDone := make(chan struct{})
+	errCount := int32(0)
+	errCallback := func(err error) {
+		current := atomic.LoadInt32(&errCount)
+		if current < expectedCallbackCalls-1 {
+			atomic.AddInt32(&errCount, 1)
+			return
+		}
+		close(callbackDone)
+	}
+
+	// create the reliable event notifier that broadcasts to notifiers created in
+	// step above
+	evNotifier, cancelEvNotifier, err := cap.NewReliableNotifier(
+		map[string]cap.EventNotifier{
+			"notifier1": notifier1,
+			"notifier2": notifier2,
+			"panic":     panicEvNotifier,
+		},
+		cap.WithOnReliableNotifierFailure(errCallback),
+	)
+	defer cancelEvNotifier()
+
+	// assert reliable notifier started without errors
+	assert.NoError(t, err)
+
+	// run a supervision tree such that it returns the output events declared above
+	events, err := ObserveSupervisorWithNotifiers(
+		context.TODO(),
+		"root",
+		cap.WithNodes(
+			WaitDoneWorker("child0"),
+			WaitDoneWorker("child1"),
+			WaitDoneWorker("child2"),
+		),
+		[]cap.Opt{},
+		[]cap.EventNotifier{
+			evNotifier,
+		},
+		func(EventManager) {},
+	)
+
+	// assert the events from the input supervision tree are the expected ones
+	AssertExactMatch(t, events, outEvents)
+
+	// we have to wait for the event notifier to process all the notifications
+	waitTillFailuresDone()
+	done1()
+	done2()
+	<-callbackDone
+}
+
+// TestReliableNotifierSlowNotifier verifies that the failure callback gets called
+// when a given event notifier is panicking
+func TestReliableNotifierSlowNotifier(t *testing.T) {
+
+	// these are the output events we are expecting from a test supervision tree
+	outEvents := []EventP{
+		WorkerStarted("root/child0"),
+		SupervisorStarted("root"),
+		WorkerTerminated("root/child0"),
+		SupervisorTerminated("root"),
+	}
+
+	evNotifier0 := slowEvNotifier(12 * time.Second)
+	// setup a concurrent safe check for timeout callback calls
+	callbacksDone := make(chan struct{})
+	// all events but the first one should timeout
+	expectedCallbackCalls := int32(len(outEvents) - 1)
+	callbackCounter := int32(0)
+	timeoutCallback := func(name string) {
+		assert.Equal(t, "slow", name)
+		current := atomic.LoadInt32(&callbackCounter)
+		if current < expectedCallbackCalls-1 {
+			atomic.AddInt32(&callbackCounter, 1)
+			return
+		}
+		close(callbacksDone)
+	}
+
+	notifier1, done1 := newBlockingNotifier(int32(len(outEvents)))
+
+	// create the reliable event notifier that broadcasts to notifiers created in
+	// step above
+	evNotifier, cancelEvNotifier, err := cap.NewReliableNotifier(
+		map[string]cap.EventNotifier{
+			"slow":     evNotifier0,
+			"notifier": notifier1,
+		},
+		// use a very small timeout to make the test run fast
+		cap.WithNotifierTimeout(100*time.Microsecond),
+		cap.WithOnNotifierTimeout(timeoutCallback),
+	)
+
+	// assert reliable notifier started without errors
+	assert.NoError(t, err)
+
+	// run a supervision tree such that it returns the output events declared above
+	events, err := ObserveSupervisorWithNotifiers(
+		context.TODO(),
+		"root",
+		cap.WithNodes(
+			WaitDoneWorker("child0"),
+		),
+		[]cap.Opt{},
+		[]cap.EventNotifier{
+			evNotifier,
+		},
+		func(EventManager) {},
+	)
+
+	// assert the events from the input supervision tree are the expected ones
+	AssertExactMatch(t, events, outEvents)
+
+	// wait for notifier1 to receive all events
+	done1()
+	<-callbacksDone
+
+	// this process is slow on unresponsive workers, so doing an async call for that
+	go cancelEvNotifier()
+}

--- a/internal/s/monitor.go
+++ b/internal/s/monitor.go
@@ -9,9 +9,9 @@ import (
 	"github.com/capatazlib/go-capataz/internal/c"
 )
 
-// nodeSepToken is the token use to separate sub-trees and child node names in
+// NodeSepToken is the token use to separate sub-trees and child node names in
 // the supervision tree
-const nodeSepToken = "/"
+const NodeSepToken = "/"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -148,7 +148,7 @@ func startChildNode(
 	if chStartErr != nil {
 		cRuntimeName := strings.Join(
 			[]string{supRuntimeName, chSpec.GetName()},
-			nodeSepToken,
+			NodeSepToken,
 		)
 		eventNotifier.processStartFailed(chSpec.GetTag(), cRuntimeName, chStartErr)
 		return c.Child{}, chStartErr


### PR DESCRIPTION
### Context

Every application that runs a Capataz supervision tree uses the existing notification system to track errors, system health checks and lifecycle of the supervision tree in general.

Despite its usefulness, it is a pretty brittle mechanism:

  *  It only allows a single notification function; to use multiple functions, we need to create a function that synchronously calls many notification functions.

  *  If there is a panic in one of the notification functions, the whole supervision system crashes

   * If one of the notification functions is slow, it will slow down all the supervision tree monitoring systems.

We want to enhance the notification system to address the issues above.

### Acceptance Criteria

  *  [x] Offer an API that can compose safely multiple event notifiers into a single event notifier

  *  [x] Tolerate panics on notification functions, and allow observability around that occurrence (callback function)

  *  [x] Tolerate slowness on notification functions, and allow observability around that occurrence (callback function)
