### PR TITLE
Introduce OneForAll restart strategy

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,11 @@
 use_flake() {
     watch_file flake.nix
     watch_file flake.lock
+    watch_file nix/shell.nix
+    watch_file nix/default.nix
     eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile")"
 }
 
+mkdir -p $(direnv_layout_dir)
 use flake
 figlet "go-Capataz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Introduce supervision restart strategy `OneForAll` (#65)
 
+* `SupervisorRestartError` explain message got enhanced with first detected error
+  on a window of time (#65)
+
 # v0.1.0 (breaking changes)
 
 * Deprecate `WithTolerance` worker option with `WithRestartTolerance` supervisor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.0
+
+* Introduce supervision restart strategy `OneForAll` (#65)
+
 # v0.1.0 (breaking changes)
 
 * Deprecate `WithTolerance` worker option with `WithRestartTolerance` supervisor

--- a/cap/permanent_one_for_all_test.go
+++ b/cap/permanent_one_for_all_test.go
@@ -8,8 +8,8 @@ package cap_test
 import (
 	"context"
 	"errors"
-	"time"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 

--- a/cap/permanent_one_for_all_test.go
+++ b/cap/permanent_one_for_all_test.go
@@ -306,17 +306,19 @@ func TestPermanentOneForAllSingleFailingWorkerReachThreshold(t *testing.T) {
 }
 
 func TestPermanentOneForAllNestedFailingWorkerReachThreshold(t *testing.T) {
+
+	// remember, error accumulation happens at the supervisor level, not the
+	// worker
+
 	parentName := "root"
 	child1 := WaitDoneWorker("child1")
 	child2, failWorker2 := FailOnSignalWorker(
-		2, // 2 errors, 2 tolerance
+		2, // 2 errors on this worker, 1 on the other worker, 3 total, 2 tolerance
 		"child2",
 		cap.WithRestart(cap.Permanent),
 	)
 	child3, failWorker3 := FailOnSignalWorker(
-		// remember, error accumulation happens at the supervisor level, not the
-		// worker
-		1, // 3 (2 + 1) errors, 2 tolerance
+		1, // 1 error on this worker, 2 on the other worker, 3 total, 2 tolerance
 		"child3",
 		cap.WithRestart(cap.Permanent),
 	)

--- a/cap/permanent_one_for_all_test.go
+++ b/cap/permanent_one_for_all_test.go
@@ -1,0 +1,622 @@
+package cap_test
+
+//
+// NOTE: If you feel it is counter-intuitive to have workers start before
+// supervisors in the assertions bellow, check stest/README.md
+//
+
+import (
+	"context"
+	"errors"
+	"time"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/cap"
+	. "github.com/capatazlib/go-capataz/internal/stest"
+)
+
+func TestPermanentOneForAllSingleCompleteWorker(t *testing.T) {
+	parentName := "root"
+	child1, completeWorker1 := CompleteOnSignalWorker(
+		3,
+		"child1",
+		cap.WithRestart(cap.Permanent),
+	)
+	child2 := WaitDoneWorker("child2")
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		cap.WithNodes(child1, child2),
+		[]cap.Opt{cap.WithStrategy(cap.OneForAll)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has completed
+			// at least once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+
+			completeWorker1()
+			evIt.SkipTill(WorkerStarted("root/child2"))
+			// ^^^ Wait till 1st restart
+
+			completeWorker1()
+			evIt.SkipTill(WorkerStarted("root/child2"))
+			// ^^^ Wait till 2nd restart
+
+			completeWorker1()
+			evIt.SkipTill(WorkerStarted("root/child2"))
+			// ^^^ Wait till 3rd restart
+
+			completeWorker1()
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			SupervisorStarted("root"),
+			// ^^^ 1) completeWorker1 starts executing here
+
+			WorkerCompleted("root/child1"),
+			WorkerTerminated("root/child2"),
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			// ^^^ 1st restart
+
+			WorkerCompleted("root/child1"),
+			WorkerTerminated("root/child2"),
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			// ^^^ 2nd restart
+
+			WorkerCompleted("root/child1"),
+			WorkerTerminated("root/child2"),
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			// ^^^ 3rd restart
+
+			WorkerTerminated("root/child2"),
+			WorkerTerminated("root/child1"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestPermanentOneForAllSingleFailingWorkerRecovers(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1 := WaitDoneWorker("child1")
+	child2, failWorker2 := FailOnSignalWorker(
+		1, "child2", cap.WithRestart(cap.Permanent),
+	)
+	child3 := WaitDoneWorker("child3")
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		cap.WithNodes(child1, child2, child3),
+		[]cap.Opt{cap.WithStrategy(cap.OneForAll)},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+
+			// 2) Start the failing behavior of child1
+			failWorker2(true /* done */)
+			evIt.SkipTill(WorkerFailed("root/child2"))
+
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerStarted("root/child3"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			WorkerStarted("root/child3"),
+			SupervisorStarted("root"),
+			// ^^^ 1) failWorker2 starts executing here
+
+			WorkerFailed("root/child2"),
+			WorkerTerminated("root/child3"),
+			WorkerTerminated("root/child1"),
+			// ^^^ 2) And then we see a new (re)start of it
+
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			WorkerStarted("root/child3"),
+			// ^^^ 3) After 1st (re)start we stop
+
+			WorkerTerminated("root/child3"),
+			WorkerTerminated("root/child2"),
+			WorkerTerminated("root/child1"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestPermanentOneForAllNestedFailingWorkerRecovers(t *testing.T) {
+	parentName := "root"
+	// Fail only one time
+	child1 := WaitDoneWorker("child1")
+	child2, failWorker2 := FailOnSignalWorker(1, "child2", cap.WithRestart(cap.Permanent))
+	child3 := WaitDoneWorker("child3")
+	tree1 := cap.NewSupervisorSpec(
+		"subtree1",
+		cap.WithNodes(child1, child2, child3),
+		cap.WithStrategy(cap.OneForAll),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		cap.WithNodes(cap.Subtree(tree1)),
+		[]cap.Opt{},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at
+			// least once
+			evIt := em.Iterator()
+
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+
+			// 2) Start the failing behavior of child1
+			failWorker2(true /* done */)
+			evIt.SkipTill(WorkerFailed("root/subtree1/child2"))
+
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerStarted("root/subtree1/child3"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ 1) Wait till root starts
+
+			WorkerFailed("root/subtree1/child2"),
+			WorkerTerminated("root/subtree1/child3"),
+			WorkerTerminated("root/subtree1/child1"),
+			// ^^^ 2) We see the failWorker1 causing the error
+
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			// ^^^ 3) After 1st (re)start we stop
+
+			WorkerTerminated("root/subtree1/child3"),
+			WorkerTerminated("root/subtree1/child2"),
+			WorkerTerminated("root/subtree1/child1"),
+			SupervisorTerminated("root/subtree1"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestPermanentOneForAllSingleFailingWorkerReachThreshold(t *testing.T) {
+	parentName := "root"
+	child1 := WaitDoneWorker("child1")
+	child2, failWorker2 := FailOnSignalWorker(
+		1,
+		"child2",
+		cap.WithRestart(cap.Permanent),
+	)
+	child3, failWorker3 := FailOnSignalWorker(
+		2,
+		"child3",
+		cap.WithRestart(cap.Permanent),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		cap.WithNodes(child1, child2, child3),
+		[]cap.Opt{
+			cap.WithRestartTolerance(2, 10*time.Second),
+			cap.WithStrategy(cap.OneForAll),
+		},
+		func(em EventManager) {
+			evIt := em.Iterator()
+
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			// (1)
+			failWorker3(false /* done */)
+			evIt.SkipTill(WorkerFailed("root/child3"))
+			evIt.SkipTill(WorkerStarted("root/child3"))
+			// ^^^ Wait till first restart
+
+			// (2)
+			failWorker2(true /* done */)
+			evIt.SkipTill(WorkerFailed("root/child2"))
+			evIt.SkipTill(WorkerStarted("root/child3"))
+			// ^^^ Wait till second restart
+
+			// (3)
+			failWorker3(true /* done */)
+			evIt.SkipTill(WorkerFailed("root/child3"))
+			evIt.SkipTill(WorkerTerminated("root/child1"))
+			// ^^^ Wait till third failure
+		},
+	)
+
+	// This should return an error given there is no other supervisor that will
+	// rescue us when error threshold reached in a child.
+	assert.Error(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			WorkerStarted("root/child3"),
+			SupervisorStarted("root"),
+			// ^^^ failWorker3 excutes here (1)
+
+			WorkerFailed("root/child3"),
+			WorkerTerminated("root/child2"),
+			WorkerTerminated("root/child1"),
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			WorkerStarted("root/child3"),
+			// ^^^ first restart
+
+			WorkerFailed("root/child2"),
+			WorkerTerminated("root/child3"),
+			WorkerTerminated("root/child1"),
+			WorkerStarted("root/child1"),
+			WorkerStarted("root/child2"),
+			WorkerStarted("root/child3"),
+			// ^^^ failWorker2 executes here (2)
+
+			// 3rd err
+			WorkerFailed("root/child3"),
+			WorkerTerminated("root/child2"),
+			WorkerTerminated("root/child1"),
+			// failWorker3 executes here (3)
+			// ^^^ Error that indicates treshold has been met
+
+			SupervisorFailed("root"),
+			// ^^^ Finish with SupervisorFailed because no parent supervisor
+			// will recover it
+		},
+	)
+}
+
+func TestPermanentOneForAllNestedFailingWorkerReachThreshold(t *testing.T) {
+	parentName := "root"
+	child1 := WaitDoneWorker("child1")
+	child2, failWorker2 := FailOnSignalWorker(
+		2, // 3 errors, 2 tolerance
+		"child2",
+		cap.WithRestart(cap.Permanent),
+	)
+	child3, failWorker3 := FailOnSignalWorker(
+		1, // 3 errors, 2 tolerance
+		"child3",
+		cap.WithRestart(cap.Permanent),
+	)
+
+	tree1 := cap.NewSupervisorSpec(
+		"subtree1",
+		cap.WithNodes(child1, child2, child3),
+		cap.WithStrategy(cap.OneForAll),
+		cap.WithRestartTolerance(2, 10*time.Second),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		cap.WithNodes(cap.Subtree(tree1)),
+		[]cap.Opt{},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at
+			// least once
+			evIt := em.Iterator()
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			// (1)
+			failWorker2(false /* done */)
+			evIt.SkipTill(WorkerFailed("root/subtree1/child2"))
+			evIt.SkipTill(WorkerStarted("root/subtree1/child3"))
+			// ^^^ Wait till first restart
+
+			// (2)
+			failWorker3(false /* done */)
+			evIt.SkipTill(WorkerFailed("root/subtree1/child3"))
+			evIt.SkipTill(WorkerStarted("root/subtree1/child3"))
+			// ^^^ Wait till second restart
+
+			// (3)
+			failWorker2(true /* done */) // 3 failures, tolerance reached
+			evIt.SkipTill(WorkerFailed("root/subtree1/child2"))
+			evIt.SkipTill(WorkerTerminated("root/subtree1/child1"))
+			// ^^^ Wait till worker failure
+
+			evIt.SkipTill(SupervisorFailed("root/subtree1"))
+			// ^^^ Wait till supervisor failure (no more WorkerStarted)
+			evIt.SkipTill(SupervisorStarted("root/subtree1"))
+			// ^^^ Wait till supervisor restarted
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ Wait till root starts
+
+			WorkerFailed("root/subtree1/child2"),
+			WorkerTerminated("root/subtree1/child3"),
+			WorkerTerminated("root/subtree1/child1"),
+			// ^^^ We see failWorker2 causing an error (1)
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			// ^^^ Wait failWorker2 restarts (1st restart)
+
+			WorkerFailed("root/subtree1/child3"),
+			WorkerTerminated("root/subtree1/child2"),
+			WorkerTerminated("root/subtree1/child1"),
+			// ^^^ Wee see failWorker3 causing the error (2)
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			// ^^^ Wait failWorker3 restarts (2nd restart)
+
+			WorkerFailed("root/subtree1/child2"),
+			WorkerTerminated("root/subtree1/child3"),
+			WorkerTerminated("root/subtree1/child1"),
+			// ^^^ Wee see failWorker2 causing an error (3); threshold has been
+			// met
+
+			SupervisorFailed("root/subtree1"),
+			// ^^^ Supervisor child surpassed error
+
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			// ^^^ IMPORTANT: Restarted Supervisor signals restart of child
+			// first
+			SupervisorStarted("root/subtree1"),
+			// ^^^ Supervisor restarted again
+
+			WorkerTerminated("root/subtree1/child3"),
+			WorkerTerminated("root/subtree1/child2"),
+			WorkerTerminated("root/subtree1/child1"),
+			SupervisorTerminated("root/subtree1"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestPermanentOneForAllNestedFailingWorkerErrorCountResets(t *testing.T) {
+	parentName := "root"
+	child1 := WaitDoneWorker("child1")
+	child2, failWorker2 := FailOnSignalWorker(
+		1, /* 1 error allowed */
+		"child2",
+		cap.WithRestart(cap.Permanent),
+	)
+	child3, failWorker3 := FailOnSignalWorker(
+		1, /* 1 error allowed */
+		"child3",
+		cap.WithRestart(cap.Permanent),
+	)
+	tree1 := cap.NewSupervisorSpec(
+		"subtree1",
+		cap.WithNodes(child1, child2, child3),
+		cap.WithStrategy(cap.OneForAll),
+		cap.WithRestartTolerance(1, 100*time.Microsecond),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		cap.WithNodes(cap.Subtree(tree1)),
+		[]cap.Opt{},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			// (1)
+			failWorker3(true /* done */)
+			evIt.SkipTill(WorkerFailed("root/subtree1/child3"))
+			evIt.SkipTill(WorkerStarted("root/subtree1/child3"))
+			// ^^^ Wait till first restart
+
+			// (2)
+			// Waiting 3 times more than tolerance window, ideally, we have
+			// a way to not rely on time.Sleep, but I can't think of a clever
+			// way (like virtual time) yet
+			time.Sleep(300 * time.Microsecond)
+			failWorker2(true /* done */)
+			evIt.SkipTill(WorkerFailed("root/subtree1/child2"))
+			evIt.SkipTill(WorkerStarted("root/subtree1/child3"))
+			// ^^^ Wait till second restart
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ Wait till root starts
+
+			WorkerFailed("root/subtree1/child3"),
+			// ^^^ We see failWorker3 causing an error (1)
+			WorkerTerminated("root/subtree1/child2"),
+			WorkerTerminated("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			// ^^^ Wait failWorker3 restarts
+
+			// 2nd err -- even though we only tolerate one error, the second
+			// error happens after the 100 microseconds window
+			WorkerFailed("root/subtree1/child2"),
+			// ^^^ Wait failWorker2 causing an error (2)
+			WorkerTerminated("root/subtree1/child3"),
+			WorkerTerminated("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			WorkerStarted("root/subtree1/child3"),
+			// ^^^ Wait failWorker2 restarts
+
+			WorkerTerminated("root/subtree1/child3"),
+			WorkerTerminated("root/subtree1/child2"),
+			WorkerTerminated("root/subtree1/child1"),
+			SupervisorTerminated("root/subtree1"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestPermanentOneForAllSiblingTerminationFailOnRestart(t *testing.T) {
+	parentName := "root"
+	child1, failWorker1 := FailOnSignalWorker(
+		3, // 3 errors, 2 tolerance
+		"child1",
+		cap.WithRestart(cap.Permanent),
+	)
+	child2 := FailTerminationWorker("child2", errors.New("child2 termination fail"))
+
+	tree1 := cap.NewSupervisorSpec(
+		"subtree1",
+		cap.WithNodes(child1, child2),
+		cap.WithStrategy(cap.OneForAll),
+		cap.WithRestartTolerance(2, 10*time.Second),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		parentName,
+		cap.WithNodes(cap.Subtree(tree1)),
+		[]cap.Opt{},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			evIt.SkipTill(SupervisorStarted("root"))
+			// ^^^ Wait till all the tree is up
+
+			failWorker1(false /* done */)
+			evIt.SkipTill(WorkerFailed("root/subtree1/child1"))
+			evIt.SkipTill(WorkerStarted("root/subtree1/child2"))
+			// ^^^ Wait till first restart
+
+			failWorker1(false /* done */)
+			evIt.SkipTill(WorkerFailed("root/subtree1/child1"))
+			evIt.SkipTill(WorkerStarted("root/subtree1/child2"))
+			// ^^^ Wait till second restart
+
+			failWorker1(true /* done */) // 3 failures
+			evIt.SkipTill(SupervisorFailed("root/subtree1"))
+			// ^^^ Wait till supervisor failure
+
+			evIt.SkipTill(SupervisorStarted("root/subtree1"))
+			// ^^^ Wait till supervisor restarted
+		},
+	)
+
+	assert.Error(t, err)
+
+	// get supervisor restart error to assert error message properties
+	var restartEv *cap.Event = nil
+	for _, ev := range events {
+		if cap.EIsSupervisorRestartError(ev) {
+			restartEv = &ev
+			break
+		}
+	}
+
+	explanation := cap.ExplainError(restartEv.Err())
+	assert.Equal(
+		t,
+		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted at least 3 times in a 10s window; the last error reported was:\n\t\t> Failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
+		explanation,
+	)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// start children from left to right
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			SupervisorStarted("root/subtree1"),
+			SupervisorStarted("root"),
+			// ^^^ Wait till root starts
+
+			// 1st err
+			WorkerFailed("root/subtree1/child1"), // runtime error
+			WorkerFailed("root/subtree1/child2"), // termination error
+			// ^^^ We see failWorker1 causing the error
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			// ^^^ Wait failWorker1 restarts
+
+			// 2nd err
+			WorkerFailed("root/subtree1/child1"), // runtime error
+			WorkerFailed("root/subtree1/child2"), // termination error
+			// ^^^ After 1st (re)start we stop
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			// ^^^ Wait failWorker1 restarts (2nd)
+
+			// 3rd err
+			WorkerFailed("root/subtree1/child1"), //runtime error
+			WorkerFailed("root/subtree1/child2"), // termination error
+			// ^^^ Error that indicates treshold has been met
+
+			SupervisorFailed("root/subtree1"),
+			// ^^^ Supervisor child surpassed error
+
+			WorkerStarted("root/subtree1/child1"),
+			WorkerStarted("root/subtree1/child2"),
+			SupervisorStarted("root/subtree1"),
+			// ^^^ Supervisor restarted again
+
+			WorkerFailed("root/subtree1/child2"), // termination error
+			WorkerTerminated("root/subtree1/child1"),
+			SupervisorFailed("root/subtree1"),
+			SupervisorFailed("root"),
+		},
+	)
+}

--- a/cap/permanent_one_for_one_test.go
+++ b/cap/permanent_one_for_one_test.go
@@ -452,7 +452,7 @@ func TestPermanentOneForOneSiblingTerminationFailOnRestart(t *testing.T) {
 	explanation := cap.ExplainError(restartEv.Err())
 	assert.Equal(
 		t,
-		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted at least 3 times in a 10s window; the last error reported was:\n\t\t> Failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
+		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted more than 2 times in a 10s window.\n\tthe original error reported was:\n\t\t> Failing child (1 out of 3)\n\tthe last error reported was:\n\t\t> Failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
 		explanation,
 	)
 

--- a/cap/permanent_one_for_one_test.go
+++ b/cap/permanent_one_for_one_test.go
@@ -452,7 +452,7 @@ func TestPermanentOneForOneSiblingTerminationFailOnRestart(t *testing.T) {
 	explanation := cap.ExplainError(restartEv.Err())
 	assert.Equal(
 		t,
-		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted at least 2 times in a 10s window; the last error reported was:\n\t\t> Failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
+		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted at least 3 times in a 10s window; the last error reported was:\n\t\t> Failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
 		explanation,
 	)
 

--- a/cap/supervisor_exports.go
+++ b/cap/supervisor_exports.go
@@ -38,6 +38,12 @@ type Strategy = s.Strategy
 // Since: 0.0.0
 var OneForOne = s.OneForOne
 
+// OneForAll is an Strategy that tells the Supervisor to restart all the
+// siblings of a failed child process
+//
+// Since: 0.2.0
+var OneForAll = s.OneForAll
+
 // CleanupResourcesFn is a function that cleans up resources that were
 // allocated in a BuildNodesFn function.
 //

--- a/cap/transient_one_for_one_test.go
+++ b/cap/transient_one_for_one_test.go
@@ -226,12 +226,12 @@ func TestTransientOneForOneSingleFailingWorkerReachThreshold(t *testing.T) {
 	assert.Equal(t, "root/worker1", kvs["supervisor.restart.node.name"])
 	assert.Equal(t, "Failing child (3 out of 3)", fmt.Sprint(kvs["supervisor.restart.node.error.msg"]))
 	assert.Equal(t, 10*time.Second, kvs["supervisor.restart.node.error.duration"])
-	assert.Equal(t, uint32(2), kvs["supervisor.restart.node.error.count"])
+	assert.Equal(t, uint32(3), kvs["supervisor.restart.node.error.count"])
 
 	explanation := cap.ExplainError(err)
 	assert.Equal(
 		t,
-		"supervisor 'root' crashed due to restart tolerance surpassed.\n\tworker node 'root/worker1' was restarted at least 2 times in a 10s window; the last error reported was:\n\t\t> Failing child (3 out of 3)",
+		"supervisor 'root' crashed due to restart tolerance surpassed.\n\tworker node 'root/worker1' was restarted at least 3 times in a 10s window; the last error reported was:\n\t\t> Failing child (3 out of 3)",
 		explanation,
 	)
 

--- a/cap/transient_one_for_one_test.go
+++ b/cap/transient_one_for_one_test.go
@@ -224,14 +224,15 @@ func TestTransientOneForOneSingleFailingWorkerReachThreshold(t *testing.T) {
 	assert.Equal(t, "supervisor crashed due to restart tolerance surpassed", err.Error())
 	assert.Equal(t, "root", kvs["supervisor.name"])
 	assert.Equal(t, "root/worker1", kvs["supervisor.restart.node.name"])
-	assert.Equal(t, "Failing child (3 out of 3)", fmt.Sprint(kvs["supervisor.restart.node.error.msg"]))
+	assert.Equal(t, "Failing child (1 out of 3)", fmt.Sprint(kvs["supervisor.restart.node.error.source.msg"]))
+	assert.Equal(t, "Failing child (3 out of 3)", fmt.Sprint(kvs["supervisor.restart.node.error.last.msg"]))
 	assert.Equal(t, 10*time.Second, kvs["supervisor.restart.node.error.duration"])
-	assert.Equal(t, uint32(3), kvs["supervisor.restart.node.error.count"])
+	assert.Equal(t, uint32(2), kvs["supervisor.restart.node.error.count"])
 
 	explanation := cap.ExplainError(err)
 	assert.Equal(
 		t,
-		"supervisor 'root' crashed due to restart tolerance surpassed.\n\tworker node 'root/worker1' was restarted at least 3 times in a 10s window; the last error reported was:\n\t\t> Failing child (3 out of 3)",
+		"supervisor 'root' crashed due to restart tolerance surpassed.\n\tworker node 'root/worker1' was restarted more than 2 times in a 10s window.\n\tthe original error reported was:\n\t\t> Failing child (1 out of 3)\n\tthe last error reported was:\n\t\t> Failing child (3 out of 3)",
 		explanation,
 	)
 

--- a/internal/c/core.go
+++ b/internal/c/core.go
@@ -10,7 +10,7 @@ func (chSpec ChildSpec) GetName() string {
 // Terminate is a synchronous procedure that halts the execution of the child. it returns an
 // error if the child fails to terminate. The second return value is false if the worker is
 // already terminated.
-func (ch Child) Terminate() (error, bool) {
+func (ch Child) Terminate() (bool, error) {
 	ch.cancel()
 	return ch.wait(ch.spec.Shutdown)
 }

--- a/internal/c/core.go
+++ b/internal/c/core.go
@@ -7,9 +7,10 @@ func (chSpec ChildSpec) GetName() string {
 	return chSpec.Name
 }
 
-// Terminate is a synchronous procedure that halts the execution of the child. it returns an
-// error if the child fails to terminate. The second return value is false if the worker is
-// already terminated.
+// Terminate is a synchronous procedure that halts the execution of the child.
+// The first return value is false if the worker is already terminated. The
+// second return value is non-nil when the child fails to terminate. If the
+// first return value is true, the second return value will always be nil.
 func (ch Child) Terminate() (bool, error) {
 	ch.cancel()
 	return ch.wait(ch.spec.Shutdown)

--- a/internal/c/core.go
+++ b/internal/c/core.go
@@ -7,8 +7,10 @@ func (chSpec ChildSpec) GetName() string {
 	return chSpec.Name
 }
 
-// Terminate is a synchronous procedure that halts the execution of the child
-func (ch Child) Terminate() error {
+// Terminate is a synchronous procedure that halts the execution of the child. it returns an
+// error if the child fails to terminate. The second return value is false if the worker is
+// already terminated.
+func (ch Child) Terminate() (error, bool) {
 	ch.cancel()
 	return ch.wait(ch.spec.Shutdown)
 }

--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -70,7 +70,7 @@ func sendNotificationToSup(
 	err error,
 	chSpec ChildSpec,
 	chRuntimeName string,
-	supNotifyCh chan<- ChildNotification,
+	supNotifyChan chan<- ChildNotification,
 	terminateCh chan<- ChildNotification,
 ) {
 	chNotification := ChildNotification{
@@ -85,17 +85,17 @@ func sendNotificationToSup(
 	// There are two ways the supervisor could receive this notification:
 	//
 	// 1) If the supervisor is running it's supervision loop (e.g. normal
-	// execution), the notification will be received over the `supNotifyCh`
+	// execution), the notification will be received over the `supNotifyChan`
 	// channel; this will execute the restart mechanisms.
 	//
 	// 2) If the supervisor is shutting down, it won't be reading the
-	// `supNotifyCh`, but instead is going to be executing the `stopChildren`
+	// `supNotifyChan`, but instead is going to be executing the `stopChildren`
 	// function, which calls the `child.Terminate` method for each of the supervised
 	// internally, this function reads the `terminateCh`.
 	//
 	select {
 	// (1)
-	case supNotifyCh <- chNotification:
+	case supNotifyChan <- chNotification:
 	// (2)
 	case terminateCh <- chNotification:
 	}
@@ -105,7 +105,7 @@ func sendNotificationToSup(
 // ChildSpec, this function will block until the spawned goroutine notifies it
 // has been initialized.
 //
-// ### The supNotifyCh value
+// ### The supNotifyChan value
 //
 // Messages sent to this channel notify the supervisor that the child's
 // goroutine has finished (either with or without an error). The runtime name of
@@ -115,7 +115,7 @@ func sendNotificationToSup(
 func (chSpec ChildSpec) DoStart(
 	startCtx context.Context,
 	supName string,
-	supNotifyCh chan<- ChildNotification,
+	supNotifyChan chan<- ChildNotification,
 ) (Child, error) {
 
 	chRuntimeName := strings.Join([]string{supName, chSpec.GetName()}, "/")
@@ -159,7 +159,7 @@ func (chSpec ChildSpec) DoStart(
 					panicErr,
 					chSpec,
 					chRuntimeName,
-					supNotifyCh,
+					supNotifyChan,
 					terminateCh,
 				)
 			}
@@ -180,7 +180,7 @@ func (chSpec ChildSpec) DoStart(
 			err,
 			chSpec,
 			chRuntimeName,
-			supNotifyCh,
+			supNotifyChan,
 			terminateCh,
 		)
 	}()

--- a/internal/c/types.go
+++ b/internal/c/types.go
@@ -11,7 +11,7 @@ type Child struct {
 	restartCount uint32
 	createdAt    time.Time
 	cancel       func()
-	wait         func(Shutdown) error
+	wait         func(Shutdown) (error, bool)
 }
 
 // GetRuntimeName returns the name of this child (once started). It will have a

--- a/internal/c/types.go
+++ b/internal/c/types.go
@@ -11,7 +11,7 @@ type Child struct {
 	restartCount uint32
 	createdAt    time.Time
 	cancel       func()
-	wait         func(Shutdown) (error, bool)
+	wait         func(Shutdown) (bool, error)
 }
 
 // GetRuntimeName returns the name of this child (once started). It will have a

--- a/internal/c/worker_test.go
+++ b/internal/c/worker_test.go
@@ -1,6 +1,5 @@
 package c_test
 
-
 import (
 	"context"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 	. "github.com/capatazlib/go-capataz/internal/stest"
 )
 
-
 func TestWorkerDoubleTermination(t *testing.T) {
 	t.Run("on healthy worker", func(t *testing.T) {
 		// internal way to transform a Node to a WorkerSpec
@@ -24,12 +22,12 @@ func TestWorkerDoubleTermination(t *testing.T) {
 		c, err := wspec.DoStart(context.Background(), "test", supNotifyChan)
 		assert.NoError(t, err)
 		// first time, is going to call the termination logic, and it should not retrun an error
-		err, isFirstTime := c.Terminate()
+		isFirstTime, err := c.Terminate()
 		assert.NoError(t, err)
 		assert.True(t, isFirstTime)
 		// at this point, the internal termination channel is closed, and this
 		// should first time should return false
-		err, isFirstTime = c.Terminate()
+		isFirstTime, err = c.Terminate()
 		assert.NoError(t, err)
 		assert.Nil(t, err)
 		assert.False(t, isFirstTime)
@@ -44,12 +42,12 @@ func TestWorkerDoubleTermination(t *testing.T) {
 		c, err := wspec.DoStart(context.Background(), "test", supNotifyChan)
 		assert.NoError(t, err)
 		// first time, is going to call the termination logic, and it should not retrun an error
-		err, isFirstTime := c.Terminate()
+		isFirstTime, err := c.Terminate()
 		assert.Error(t, err)
 		assert.True(t, isFirstTime)
 		// at this point, the internal termination channel is closed, and this
 		// should first time should return false
-		err, isFirstTime = c.Terminate()
+		isFirstTime, err = c.Terminate()
 		assert.NoError(t, err)
 		assert.Nil(t, err)
 		assert.False(t, isFirstTime)

--- a/internal/c/worker_test.go
+++ b/internal/c/worker_test.go
@@ -21,7 +21,7 @@ func TestWorkerDoubleTermination(t *testing.T) {
 		supNotifyChan := make(chan c.ChildNotification)
 		c, err := wspec.DoStart(context.Background(), "test", supNotifyChan)
 		assert.NoError(t, err)
-		// first time, is going to call the termination logic, and it should not retrun an error
+		// first time, is going to call the termination logic, and it should not return an error
 		isFirstTime, err := c.Terminate()
 		assert.NoError(t, err)
 		assert.True(t, isFirstTime)

--- a/internal/c/worker_test.go
+++ b/internal/c/worker_test.go
@@ -20,8 +20,8 @@ func TestWorkerDoubleTermination(t *testing.T) {
 		// internal way to transform a Node to a WorkerSpec
 		wspec := WaitDoneWorker("worker")(s.SupervisorSpec{})
 
-		supNotifyCh := make(chan c.ChildNotification)
-		c, err := wspec.DoStart(context.Background(), "test", supNotifyCh)
+		supNotifyChan := make(chan c.ChildNotification)
+		c, err := wspec.DoStart(context.Background(), "test", supNotifyChan)
 		assert.NoError(t, err)
 		// first time, is going to call the termination logic, and it should not retrun an error
 		err, isFirstTime := c.Terminate()
@@ -40,8 +40,8 @@ func TestWorkerDoubleTermination(t *testing.T) {
 			"worker", fmt.Errorf("failing worker"),
 		)(s.SupervisorSpec{})
 
-		supNotifyCh := make(chan c.ChildNotification)
-		c, err := wspec.DoStart(context.Background(), "test", supNotifyCh)
+		supNotifyChan := make(chan c.ChildNotification)
+		c, err := wspec.DoStart(context.Background(), "test", supNotifyChan)
 		assert.NoError(t, err)
 		// first time, is going to call the termination logic, and it should not retrun an error
 		err, isFirstTime := c.Terminate()

--- a/internal/c/worker_test.go
+++ b/internal/c/worker_test.go
@@ -25,8 +25,7 @@ func TestWorkerDoubleTermination(t *testing.T) {
 		isFirstTime, err := c.Terminate()
 		assert.NoError(t, err)
 		assert.True(t, isFirstTime)
-		// at this point, the internal termination channel is closed, and this
-		// should first time should return false
+
 		isFirstTime, err = c.Terminate()
 		assert.NoError(t, err)
 		assert.Nil(t, err)
@@ -46,7 +45,7 @@ func TestWorkerDoubleTermination(t *testing.T) {
 		assert.Error(t, err)
 		assert.True(t, isFirstTime)
 		// at this point, the internal termination channel is closed, and this
-		// should first time should return false
+		// returns an error only the first time it is called.
 		isFirstTime, err = c.Terminate()
 		assert.NoError(t, err)
 		assert.Nil(t, err)

--- a/internal/c/worker_test.go
+++ b/internal/c/worker_test.go
@@ -1,0 +1,58 @@
+package c_test
+
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/internal/c"
+	"github.com/capatazlib/go-capataz/internal/s"
+
+	. "github.com/capatazlib/go-capataz/internal/stest"
+)
+
+
+func TestWorkerDoubleTermination(t *testing.T) {
+	t.Run("on healthy worker", func(t *testing.T) {
+		// internal way to transform a Node to a WorkerSpec
+		wspec := WaitDoneWorker("worker")(s.SupervisorSpec{})
+
+		supNotifyCh := make(chan c.ChildNotification)
+		c, err := wspec.DoStart(context.Background(), "test", supNotifyCh)
+		assert.NoError(t, err)
+		// first time, is going to call the termination logic, and it should not retrun an error
+		err, isFirstTime := c.Terminate()
+		assert.NoError(t, err)
+		assert.True(t, isFirstTime)
+		// at this point, the internal termination channel is closed, and this
+		// should first time should return false
+		err, isFirstTime = c.Terminate()
+		assert.NoError(t, err)
+		assert.Nil(t, err)
+		assert.False(t, isFirstTime)
+	})
+	t.Run("on termination failing worker", func(t *testing.T) {
+		// internal way to transform a Node to a WorkerSpec
+		wspec := FailTerminationWorker(
+			"worker", fmt.Errorf("failing worker"),
+		)(s.SupervisorSpec{})
+
+		supNotifyCh := make(chan c.ChildNotification)
+		c, err := wspec.DoStart(context.Background(), "test", supNotifyCh)
+		assert.NoError(t, err)
+		// first time, is going to call the termination logic, and it should not retrun an error
+		err, isFirstTime := c.Terminate()
+		assert.Error(t, err)
+		assert.True(t, isFirstTime)
+		// at this point, the internal termination channel is closed, and this
+		// should first time should return false
+		err, isFirstTime = c.Terminate()
+		assert.NoError(t, err)
+		assert.Nil(t, err)
+		assert.False(t, isFirstTime)
+
+	})
+}

--- a/internal/c/worker_test.go
+++ b/internal/c/worker_test.go
@@ -40,7 +40,8 @@ func TestWorkerDoubleTermination(t *testing.T) {
 		supNotifyChan := make(chan c.ChildNotification)
 		c, err := wspec.DoStart(context.Background(), "test", supNotifyChan)
 		assert.NoError(t, err)
-		// first time, is going to call the termination logic, and it should not retrun an error
+		// first time, is going to call the termination logic, and it should not
+		// return an error
 		isFirstTime, err := c.Terminate()
 		assert.Error(t, err)
 		assert.True(t, isFirstTime)

--- a/internal/s/dyn_supervisor.go
+++ b/internal/s/dyn_supervisor.go
@@ -20,7 +20,7 @@ type ctrlMsg interface {
 		specChildren []c.ChildSpec,
 		supRuntimeName string,
 		supChildren map[string]c.Child,
-		supNotifyCh chan c.ChildNotification,
+		supNotifyChan chan c.ChildNotification,
 	) ([]c.ChildSpec, map[string]c.Child)
 }
 
@@ -44,15 +44,15 @@ func (scm startChildMsg) processMsg(
 	specChildren []c.ChildSpec,
 	supRuntimeName string,
 	supChildren map[string]c.Child,
-	supNotifyCh chan c.ChildNotification,
+	supNotifyChan chan c.ChildNotification,
 ) ([]c.ChildSpec, map[string]c.Child) {
 	// REMEMBER: WE ARE RUNNING THIS CODE IN THE SUPERVISOR THREAD
 
 	childSpec := scm.node(spec)
 
-	ch, startErr := startChildNode(supCtx, spec, supRuntimeName, supNotifyCh, childSpec)
+	ch, startErr := startChildNode(supCtx, spec, supRuntimeName, supNotifyChan, childSpec)
 	if startErr != nil {
-		// When we fail, we send an error to the supNotifyCh and return the error,
+		// When we fail, we send an error to the supNotifyChan and return the error,
 		// this doesn't have any detrimental consequence in static supervisors,
 		// but on dynamic supervisors, it means the monitor loop will get bothered
 		// with an error that it should not really handle. We are going to read it
@@ -107,7 +107,7 @@ func (tcm terminateChildMsg) processMsg(
 	specChildren []c.ChildSpec,
 	supRuntimeName string,
 	supChildren map[string]c.Child,
-	supNotifyCh chan c.ChildNotification,
+	supNotifyChan chan c.ChildNotification,
 ) ([]c.ChildSpec, map[string]c.Child) {
 	// REMEMBER: WE ARE RUNNING THIS CODE IN THE SUPERVISOR THREAD
 
@@ -163,7 +163,7 @@ func handleCtrlMsg(
 	specChildren []c.ChildSpec,
 	supRuntimeName string,
 	supChildren map[string]c.Child,
-	supNotifyCh chan c.ChildNotification,
+	supNotifyChan chan c.ChildNotification,
 	msg ctrlMsg,
 ) ([]c.ChildSpec, map[string]c.Child) {
 	return msg.processMsg(
@@ -173,7 +173,7 @@ func handleCtrlMsg(
 		specChildren,
 		supRuntimeName,
 		supChildren,
-		supNotifyCh,
+		supNotifyChan,
 	)
 }
 

--- a/internal/s/dyn_supervisor.go
+++ b/internal/s/dyn_supervisor.go
@@ -57,7 +57,7 @@ func (scm startChildMsg) processMsg(
 		// but on dynamic supervisors, it means the monitor loop will get bothered
 		// with an error that it should not really handle. We are going to read it
 		// out and return after that.
-		_ = <-supNotifyCh
+		_ = <-supNotifyChan
 		// do not block waiting for a read
 		select {
 		case scm.resultChan <- startChildResult{

--- a/internal/s/error.go
+++ b/internal/s/error.go
@@ -422,20 +422,26 @@ type RestartToleranceReached struct {
 	failedChildName        string
 	failedChildErrCount    uint32
 	failedChildErrDuration time.Duration
-	err                    error
+	sourceErr              error
+	lastErr                error
 }
 
 // NewRestartToleranceReached creates an ErrorToleranceReached record
 func NewRestartToleranceReached(
 	tolerance restartTolerance,
-	err error,
-	ch c.Child,
+	sourceCh c.Child,
+	sourceErr error,
+	lastErr error,
 ) *RestartToleranceReached {
 	return &RestartToleranceReached{
-		failedChildName:        ch.GetRuntimeName(),
-		failedChildErrCount:    tolerance.MaxRestartCount,
+		failedChildName:        sourceCh.GetRuntimeName(),
+		// we want to indicate that MaxRestartCount is less than the
+		// current error count, given this, we need to increment this
+		// number by one
+		failedChildErrCount:    tolerance.MaxRestartCount + 1,
 		failedChildErrDuration: tolerance.RestartWindow,
-		err:                    err,
+		sourceErr:              sourceErr,
+		lastErr:                lastErr,
 	}
 }
 
@@ -443,8 +449,8 @@ func NewRestartToleranceReached(
 func (err *RestartToleranceReached) KVs() map[string]interface{} {
 	kvs := make(map[string]interface{})
 	kvs["node.name"] = err.failedChildName
-	if err.err != nil {
-		kvs["node.error.msg"] = err.err.Error()
+	if err.lastErr != nil {
+		kvs["node.error.msg"] = err.lastErr.Error()
 		kvs["node.error.count"] = err.failedChildErrCount
 		kvs["node.error.duration"] = err.failedChildErrDuration
 	}
@@ -458,7 +464,7 @@ func (err *RestartToleranceReached) Error() string {
 // Unwrap returns the last error that caused the creation of an
 // ErrorToleranceReached error
 func (err *RestartToleranceReached) Unwrap() error {
-	return err.err
+	return err.lastErr
 }
 
 // explainLines returns a human-friendly message of the error represented as a slice
@@ -479,7 +485,7 @@ func (err *RestartToleranceReached) explainLines() []string {
 	)
 	outputLines = append(
 		outputLines,
-		indentExplain(1, errToExplain(err.err))...,
+		indentExplain(1, errToExplain(err.lastErr))...,
 	)
 	return outputLines
 }

--- a/internal/s/error.go
+++ b/internal/s/error.go
@@ -434,7 +434,7 @@ func NewRestartToleranceReached(
 	lastErr error,
 ) *RestartToleranceReached {
 	return &RestartToleranceReached{
-		failedChildName:        sourceCh.GetRuntimeName(),
+		failedChildName: sourceCh.GetRuntimeName(),
 		// we want to indicate that MaxRestartCount is less than the
 		// current error count, given this, we need to increment this
 		// number by one

--- a/internal/s/monitor.go
+++ b/internal/s/monitor.go
@@ -84,7 +84,6 @@ func execRestartLoop(
 	}
 }
 
-
 func handleChildNodeError(
 	supCtx context.Context,
 	supTolerance *restartToleranceManager,
@@ -152,9 +151,9 @@ func handleChildNodeCompletion(
 			supCtx,
 			supTolerance,
 			supSpec, supChildSpecs,
-			supRuntimeName,  supChildren, supNotifyChan,
+			supRuntimeName, supChildren, supNotifyChan,
 			sourceCh,
-			nil /* error */,
+			nil, /* error */
 		)
 	}
 }
@@ -272,7 +271,6 @@ func startChildNode(
 	return ch, nil
 }
 
-
 // TODO: introduce shouldSkip when supporting RestForOne functionality
 
 // startChildNodes iterates over all the children (specified with `cap.WithNodes`
@@ -337,7 +335,7 @@ func terminateChildNode(
 ) error {
 	chSpec := ch.GetSpec()
 	stoppingTime := time.Now()
-	terminationErr, isFirstTermination := ch.Terminate()
+	isFirstTermination, terminationErr := ch.Terminate()
 
 	// if it is not the first termination (it was terminated before, or finished because
 	// of a failure), we have already made notice of this termination before, so we are

--- a/internal/s/monitor.go
+++ b/internal/s/monitor.go
@@ -31,7 +31,7 @@ func getRestartStrategy(supSpec SupervisorSpec) strategyRestartFn {
 	case OneForAll:
 		return oneForAllRestart
 	default:
-		panic("unknown restarte strategy, check getRestartStrategy implementation")
+		panic("unknown restart strategy, check getRestartStrategy implementation")
 	}
 }
 

--- a/internal/s/monitor.go
+++ b/internal/s/monitor.go
@@ -56,6 +56,10 @@ func execRestartLoop(
 		if prevErr != nil {
 			ok := supTolerance.checkTolerance()
 			if !ok {
+				// Very important! even though we return an error value
+				// here, we want to return a supChildren, this collection
+				// gets replaced on every iteration, and if we return a nil
+				// value, all children well not be terminated.
 				return supChildren, NewRestartToleranceReached(
 					supTolerance.restartTolerance,
 					sourceCh,

--- a/internal/s/one_for_all.go
+++ b/internal/s/one_for_all.go
@@ -1,0 +1,32 @@
+package s
+
+import (
+	"context"
+	"github.com/capatazlib/go-capataz/internal/c"
+)
+
+func oneForAllRestart(
+	supCtx context.Context,
+	spec SupervisorSpec, supChildrenSpecs []c.ChildSpec,
+
+	supRuntimeName string,
+	supChildren0 map[string]c.Child,
+	supNotifyChan chan c.ChildNotification,
+
+	sourceCh c.Child,
+) (map[string]c.Child, error) {
+	// we do not want to stop the restart procedure if a termination fails,
+	// nonetheless, this error is not going unnoticed given the event
+	// notifier gets called on child termination.
+	_ /* nodeErrMap */ = terminateChildNodes(
+		spec, supChildrenSpecs, supChildren0, skipChild(sourceCh),
+	)
+
+	return startChildNodes(
+		supCtx,
+		spec,
+		supChildrenSpecs,
+		supRuntimeName,
+		supNotifyChan,
+	)
+}

--- a/internal/s/one_for_all.go
+++ b/internal/s/one_for_all.go
@@ -5,7 +5,6 @@ import (
 	"github.com/capatazlib/go-capataz/internal/c"
 )
 
-
 var oneForAllRestart strategyRestartFn = func(
 	supCtx context.Context,
 	spec SupervisorSpec, supChildrenSpecs []c.ChildSpec,

--- a/internal/s/one_for_all.go
+++ b/internal/s/one_for_all.go
@@ -5,7 +5,8 @@ import (
 	"github.com/capatazlib/go-capataz/internal/c"
 )
 
-func oneForAllRestart(
+
+var oneForAllRestart strategyRestartFn = func(
 	supCtx context.Context,
 	spec SupervisorSpec, supChildrenSpecs []c.ChildSpec,
 

--- a/internal/s/one_for_one.go
+++ b/internal/s/one_for_one.go
@@ -7,7 +7,7 @@ import (
 	"github.com/capatazlib/go-capataz/internal/c"
 )
 
-func oneForOneRestart(
+var oneForOneRestart strategyRestartFn = func(
 	supCtx context.Context,
 	spec SupervisorSpec, supChildrenSpecs []c.ChildSpec,
 

--- a/internal/s/one_for_one.go
+++ b/internal/s/one_for_one.go
@@ -9,72 +9,32 @@ import (
 
 func oneForOneRestart(
 	supCtx context.Context,
-	eventNotifier EventNotifier,
+	spec SupervisorSpec, supChildrenSpecs []c.ChildSpec,
+
 	supRuntimeName string,
 	supChildren map[string]c.Child,
-	supNotifyCh chan<- c.ChildNotification,
-	prevCh c.Child,
-) (c.Child, error) {
-	chSpec := prevCh.GetSpec()
+	supNotifyChan chan c.ChildNotification,
+
+	sourceCh c.Child,
+) (map[string]c.Child, error) {
+	eventNotifier := spec.getEventNotifier()
+
+	chSpec := sourceCh.GetSpec()
 	chName := chSpec.GetName()
 
 	startTime := time.Now()
-	newCh, chRestartErr := chSpec.DoStart(supCtx, supRuntimeName, supNotifyCh)
+	newCh, chRestartErr := chSpec.DoStart(supCtx, supRuntimeName, supNotifyChan)
 
 	if chRestartErr != nil {
-		return c.Child{}, chRestartErr
+		return supChildren, chRestartErr
 	}
 
 	supChildren[chName] = newCh
 
-	// notify event only for workers, supervisors are responsible of their own
+	// notify event only for workers, supervisors are responsible of their
+	// own notifications
 	if newCh.GetTag() == c.Worker {
 		eventNotifier.workerStarted(newCh.GetRuntimeName(), startTime)
 	}
-	return newCh, nil
-}
-
-func oneForOneRestartLoop(
-	supCtx context.Context,
-	eventNotifier EventNotifier,
-	supRuntimeName string,
-	supTolerance *restartToleranceManager,
-	supChildren map[string]c.Child,
-	supNotifyCh chan<- c.ChildNotification,
-	prevCh c.Child,
-	prevChErr error,
-) *RestartToleranceReached {
-	// we initialize prevErr with the original child error that caused this logic
-	// to get executed. It could happen that this error gets eclipsed by a restart
-	// error later on
-	prevErr := prevChErr
-
-	for {
-		if prevChErr != nil {
-			ok := supTolerance.checkTolerance()
-			if !ok {
-				// Remove children from runtime child map to skip terminate procedure
-				delete(supChildren, prevCh.GetName())
-				return NewRestartToleranceReached(supTolerance.restartTolerance, prevErr, prevCh)
-			}
-		}
-
-		newCh, restartErr := oneForOneRestart(
-			supCtx,
-			eventNotifier,
-			supRuntimeName,
-			supChildren,
-			supNotifyCh,
-			prevCh,
-		)
-
-		// if we don't get restart errors, break the loop
-		if restartErr == nil {
-			return nil
-		}
-
-		// otherwise, repeat until restart tolerance is reached
-		prevCh = newCh
-		prevErr = restartErr
-	}
+	return supChildren, nil
 }

--- a/internal/s/one_for_one.go
+++ b/internal/s/one_for_one.go
@@ -26,6 +26,10 @@ func oneForOneRestart(
 	newCh, chRestartErr := chSpec.DoStart(supCtx, supRuntimeName, supNotifyChan)
 
 	if chRestartErr != nil {
+		// Very important! even though we return an error value here, we want to
+		// return a supChildren, this collection gets replaced on every iteration,
+		// and if we return a nil value, all children won't get terminated
+		// appropietly.
 		return supChildren, chRestartErr
 	}
 

--- a/internal/s/spec.go
+++ b/internal/s/spec.go
@@ -63,7 +63,7 @@ const (
 	// OneForOne is an Strategy that tells the Supervisor to only restart the
 	// child process that errored
 	OneForOne Strategy = iota
-	// OneForAll
+	OneForAll
 	// RestForOne
 )
 

--- a/internal/s/spec.go
+++ b/internal/s/spec.go
@@ -63,6 +63,8 @@ const (
 	// OneForOne is an Strategy that tells the Supervisor to only restart the
 	// child process that errored
 	OneForOne Strategy = iota
+	// OneForAll is an Strategy that tells the Supervisor to restart all the
+	// siblings of a failed child process
 	OneForAll
 	// RestForOne
 )

--- a/internal/s/supervisor.go
+++ b/internal/s/supervisor.go
@@ -59,16 +59,18 @@ func (tm *terminationManager) setTerminationErr(err error) {
 // restartToleranceManager contains the information required to lear if a surpervisor
 // surpassed error tolerance
 type restartToleranceManager struct {
+	sourceErr        error
 	restartTolerance restartTolerance
 	restartCount     uint32
 	restartBeginTime time.Time
 }
 
-// checkTolerance adds a new failure on the error tolerance calculation, if the
+// checkToleranceExceeded adds a new failure on the error tolerance calculation, if the
 // number of errors is enough to surpass tolerance, it will return false,
 // otherwise it will modify it's restart count and return true.
-func (mgr *restartToleranceManager) checkTolerance() bool {
+func (mgr *restartToleranceManager) checkToleranceExceeded(err error) bool {
 	if mgr.restartBeginTime == (time.Time{}) {
+		mgr.sourceErr = err
 		mgr.restartBeginTime = time.Now()
 	}
 
@@ -83,6 +85,7 @@ func (mgr *restartToleranceManager) checkTolerance() bool {
 		return true
 	case resetRestartCount:
 		// not zero given we need to account for the error that just happened
+		mgr.sourceErr = err
 		mgr.restartCount = 1
 		mgr.restartBeginTime = time.Now()
 		return true

--- a/internal/stest/workers.go
+++ b/internal/stest/workers.go
@@ -83,7 +83,11 @@ func FailOnSignalWorker(
 	return cap.NewWorker(
 		name,
 		func(ctx context.Context) error {
-			<-startCh
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-startCh:
+			}
 			if currentFailCount < totalErrCount {
 				atomic.AddInt32(&currentFailCount, 1)
 				return fmt.Errorf("Failing child (%d out of %d)", currentFailCount, totalErrCount)

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,7 +11,7 @@ pkgs.mkShell {
 
     # recommended packages to have for development with emacs/spacemacs
     gotools godef gocode golint golangci-lint gogetdoc gopkgs gotests impl
-    errcheck reftools humanlog delve gopls gomod2nix
+    errcheck reftools humanlog delve gopls gomod2nix gopls
 
     # capataz deps
     go-capataz


### PR DESCRIPTION
### Context

This PR allows clients to use the `cap.WithStrategy(cap.OneForAll)` functionality.

### Changes

Changes are happening in the internal library and they include:

* Formalization of the restart logic

  Now all restarting functions follow the same signature (independently if they need all arguments or not). Also, we generalized the function `oneForOneRestartLoop` into the `execRestartStrategy` function.

* `terminateChildren` function now accepts a `shouldSkip` argument, this is used to decide which child nodes to skip termination when restarting all children of a tree.

* The `Child.Terminate` method returns a boolean indicating if the given termination was already done. This allows us to skip notifications of already terminated children.