### PR TITLE
add DynSubtree API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * `SupervisorRestartError` explain message got enhanced with first detected error
   on a window of time (#65)
 
+* Introduce `NewDynSubtree` and `NewDynSubtreeWithNotifyStart` to create managed
+  subtrees with dynamic worker spawning capabilities. (#66)
+
 # v0.1.0 (breaking changes)
 
 * Deprecate `WithTolerance` worker option with `WithRestartTolerance` supervisor

--- a/cap/supervisor_exports.go
+++ b/cap/supervisor_exports.go
@@ -309,6 +309,27 @@ type DynSupervisor = s.DynSupervisor
 // Since: 0.0.0
 var NewDynSupervisor = s.NewDynSupervisor
 
+// Spawner is a builder type that can spawn other workers
+//
+// since: 0.2.0
+type Spawner = s.Spawner
+
+// NewDynSubtree builds a worker that has receives a Spawner that allows it to
+// create more child workers dynamically in a sub-tree.
+//
+// Note: The Spawner is automatically managed by the supervision tree, so
+// clients are not required to terminate it explicitly.
+//
+// since: 0.2.0
+var NewDynSubtree = s.NewDynSubtree
+
+// NewDynSubtreeWithNotifyStart accomplishes the same goal as NewDynSubtree with
+// the addition of passing an extra argument (notifyStart callback) to the
+// startFn function parameter.
+//
+// since: 0.2.0
+var NewDynSubtreeWithNotifyStart = s.NewDynSubtreeWithNotifyStart
+
 // Supervisor represents the root of a tree of goroutines. A Supervisor may have
 // leaf or sub-tree children, where each of the nodes in the tree represent a
 // goroutine that gets automatic restart abilities as soon as the parent

--- a/internal/n/reliable_notifier.go
+++ b/internal/n/reliable_notifier.go
@@ -185,7 +185,6 @@ func NewReliableNotifier(
 		// this logic running (and failing in the background)
 		s.WithRestartTolerance(100, 1*time.Second),
 		s.WithNotifier(notifyRootFailure(settings)),
-		// TODO: Add OneForAll strategy here
 	)
 
 	reliableNotifier, startErr := reliableNotifierSpec.Start(context.Background())

--- a/internal/s/dyn_subtree.go
+++ b/internal/s/dyn_subtree.go
@@ -1,0 +1,97 @@
+package s
+
+import (
+	"context"
+
+	"github.com/capatazlib/go-capataz/internal/c"
+)
+
+// Spawner is a record that can spawn other workers, and can wait
+// for termination
+type Spawner interface {
+	Spawn(Node) (func() error, error)
+}
+
+type spawnerClient struct {
+	ctrlChan chan ctrlMsg
+}
+
+func newSpawnerClient(ctrlChan chan ctrlMsg) spawnerClient {
+	return spawnerClient{ctrlChan: ctrlChan}
+}
+
+func (s spawnerClient) Spawn(node Node) (func() error, error) {
+	return sendSpawnToSupervisor(s.ctrlChan, node)
+}
+
+// NewDynSubtree builds a worker that has receives a Spawner that allows it to
+// create more child workers dynamically in a sub-tree.
+//
+// Note: The Spawner is automatically managed by the supervision tree, so
+// clients are not required to terminate it explicitly.
+//
+func NewDynSubtree(
+	name string,
+	startFn func(context.Context, Spawner) error,
+	spawnerOpts []Opt,
+	opts ...c.Opt,
+) Node {
+	return NewDynSubtreeWithNotifyStart(
+		name,
+		func(ctx context.Context, notifyStart NotifyStartFn, spawner Spawner) error {
+			notifyStart(nil)
+			return startFn(ctx, spawner)
+		},
+		spawnerOpts,
+		opts...,
+	)
+}
+
+// NewDynSubtreeWithNotifyStart accomplishes the same goal as NewDynSubtree with
+// the addition of passing an extra argument (notifyStart callback) to the
+// startFn function parameter.
+func NewDynSubtreeWithNotifyStart(
+	name string,
+	runFn func(context.Context, NotifyStartFn, Spawner) error,
+	spawnerOpts []Opt,
+	opts ...c.Opt,
+) Node {
+	return func(supSpec SupervisorSpec) c.ChildSpec {
+		dynSubtreeSpec := NewSupervisorSpec(
+			name,
+			func() ([]Node, CleanupResourcesFn, error) {
+				// we cannot create the dynamic supervisor here because
+				// we don't have a context to build it with. We are going
+				// to create a promise of a value so that the worker has access
+				// to it later
+				ctrlChan := make(chan ctrlMsg)
+
+				spawnerSpec := NewSupervisorSpec("spawner", WithNodes(), spawnerOpts...)
+				spawnerNode := func(parent SupervisorSpec) c.ChildSpec {
+					return parent.subtree(spawnerSpec, ctrlChan, opts...)
+				}
+
+				cleanup := func() error { return nil }
+
+				return []Node{
+					spawnerNode,
+					NewWorkerWithNotifyStart(
+						"worker",
+						func(ctx context.Context, notifyStart NotifyStartFn) error {
+							// we create a value that allows us to communicate with the
+							// spawner supervision sub-tree in a safe way.
+							spawner := newSpawnerClient(ctrlChan)
+							return runFn(ctx, notifyStart, spawner)
+						},
+						opts...,
+					),
+				}, cleanup, nil
+			},
+			// if the dynamic sub-tree or the spawner node fail, restart both of them
+			WithStrategy(OneForAll),
+		)
+
+		ctrlChan := make(chan ctrlMsg)
+		return supSpec.subtree(dynSubtreeSpec, ctrlChan)
+	}
+}

--- a/internal/s/dyn_subtree.go
+++ b/internal/s/dyn_subtree.go
@@ -81,7 +81,6 @@ func NewDynSubtreeWithNotifyStart(
 				}
 
 				cleanup := func() error {
-					close(ctrlChan)
 					return nil
 				}
 

--- a/internal/s/dyn_subtree_test.go
+++ b/internal/s/dyn_subtree_test.go
@@ -1,0 +1,312 @@
+package s_test
+
+//
+// NOTE: If you feel it is counter-intuitive to have workers start before
+// supervisors in the assertions below, check stest/README.md
+//
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capatazlib/go-capataz/cap"
+	. "github.com/capatazlib/go-capataz/internal/stest"
+)
+
+func TestDynSubtreeStartSingleChild(t *testing.T) {
+	subtree := WaitDoneDynSubtree(
+		"one", []cap.Opt{}, []cap.WorkerOpt{}, WaitDoneWorker("uno"),
+	)
+
+	events, errs := ObserveSupervisor(
+		context.TODO(),
+		"root",
+		cap.WithNodes(subtree),
+		[]cap.Opt{},
+		func(EventManager) {},
+	)
+	assert.Empty(t, errs)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// The dyn-subtree spawner sub-tree starts always first
+			SupervisorStarted("root/one/spawner"),
+			WorkerStarted("root/one/spawner/uno"),
+			// Then the dyn-subtree worker
+			WorkerStarted("root/one/worker"),
+			// Then dyn-subtree as a whole is started
+			SupervisorStarted("root/one"),
+			SupervisorStarted("root"),
+			// stop occurs in reverse order of start
+			WorkerTerminated("root/one/worker"),
+			WorkerTerminated("root/one/spawner/uno"),
+			SupervisorTerminated("root/one/spawner"),
+			SupervisorTerminated("root/one"),
+			SupervisorTerminated("root"),
+		})
+}
+
+func TestDynSubtreeFailing(t *testing.T) {
+	// Fail only one time
+	child1, failSubtree1 := FailOnSignalDynSubtree(
+		1,
+		"one",
+		[]cap.Opt{},
+		[]cap.WorkerOpt{},
+		WaitDoneWorker("uno"),
+		WaitDoneWorker("dos"),
+		WaitDoneWorker("tres"),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		"root",
+		cap.WithNodes(child1),
+		[]cap.Opt{},
+		func(em EventManager) {
+			// NOTE: we won't stop the supervisor until the child has failed at least
+			// once
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			failSubtree1(true /* done */)
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerStarted("root/one/worker"))
+		},
+	)
+
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// The dyn-subtree spawner sub-tree starts always first
+			SupervisorStarted("root/one/spawner"),
+			// then, because of the FailOnSignalDynSubtree implementation the dyn
+			// supervisor children start first
+			WorkerStarted("root/one/spawner/uno"),
+			WorkerStarted("root/one/spawner/dos"),
+			WorkerStarted("root/one/spawner/tres"),
+			// then dyn-subtree worker
+			WorkerStarted("root/one/worker"),
+			// the the dyn-subtree as a whole
+			SupervisorStarted("root/one"),
+			// finally the root supervisor
+			SupervisorStarted("root"),
+
+			// signal of error starts here
+			WorkerFailed("root/one/worker"),
+			// the dyn sub-tree has a wired strategy of OneForAll, so the dyn-subtree
+			// spawner also gets terminated on error
+			WorkerTerminated("root/one/spawner/tres"),
+			WorkerTerminated("root/one/spawner/dos"),
+			WorkerTerminated("root/one/spawner/uno"),
+			SupervisorTerminated("root/one/spawner"),
+
+			// the spawner sub-tree gets started first after a restart
+			SupervisorStarted("root/one/spawner"),
+			WorkerStarted("root/one/spawner/uno"),
+			WorkerStarted("root/one/spawner/dos"),
+			WorkerStarted("root/one/spawner/tres"),
+			WorkerStarted("root/one/worker"),
+
+			// dyn subtree terminates in reverse order
+			WorkerTerminated("root/one/worker"),
+			WorkerTerminated("root/one/spawner/tres"),
+			WorkerTerminated("root/one/spawner/dos"),
+			WorkerTerminated("root/one/spawner/uno"),
+			SupervisorTerminated("root/one/spawner"),
+			SupervisorTerminated("root/one"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestDynSubtreeFailedSpawnedWorker(t *testing.T) {
+	worker1, failWorker1 := FailOnSignalWorker(2, "child1")
+	subtree := WaitDoneDynSubtree(
+		"one",
+		[]cap.Opt{},
+		[]cap.WorkerOpt{},
+		WaitDoneWorker("child0"),
+		worker1,
+		WaitDoneWorker("child2"),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		"root",
+		cap.WithNodes(subtree),
+		[]cap.Opt{},
+		func(em EventManager) {
+			evIt := em.Iterator()
+			// 1) Wait till all the tree is up
+			evIt.SkipTill(SupervisorStarted("root"))
+			// 2) Start the failing behavior of child1
+			failWorker1(false /* done */)
+			// 3) Wait till first restart
+			evIt.SkipTill(WorkerStarted("root/one/spawner/child1"))
+			// 4) fail again to surpass default error threshold (2 in 5 seconds)
+			failWorker1(true /* done */)
+			// one_for_all strategy makes the whole dyn-subtree starts
+			// 5) wait for the whole dyn-subtree one gets started
+			evIt.SkipTill(WorkerStarted("root/one/worker"))
+		},
+	)
+
+	// assert that error contains all information required to assess what went wrong
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// The dyn-subtree spawner sub-tree starts always first
+			SupervisorStarted("root/one/spawner"),
+			WorkerStarted("root/one/spawner/child0"),
+			WorkerStarted("root/one/spawner/child1"),
+			WorkerStarted("root/one/spawner/child2"),
+			WorkerStarted("root/one/worker"),
+			SupervisorStarted("root/one"),
+			SupervisorStarted("root"),
+
+			// failure one starts here
+			WorkerFailed("root/one/spawner/child1"),
+			WorkerStarted("root/one/spawner/child1"),
+			// failure two starts here, one_for_all got triggered here
+			WorkerFailed("root/one/spawner/child1"),
+			WorkerTerminated("root/one/spawner/child2"),
+			WorkerTerminated("root/one/spawner/child0"),
+			SupervisorFailed("root/one/spawner"),
+			WorkerTerminated("root/one/worker"),
+
+			// one_for_all start here
+			//
+			// remember, supervisor starts first because it's children are started
+			// dynamically by the WaitDoneDynSubtree implementation
+			SupervisorStarted("root/one/spawner"),
+			WorkerStarted("root/one/spawner/child0"),
+			WorkerStarted("root/one/spawner/child1"),
+			WorkerStarted("root/one/spawner/child2"),
+			WorkerStarted("root/one/worker"),
+
+			// dyn subtree terminates in reverse order
+			WorkerTerminated("root/one/worker"),
+			WorkerTerminated("root/one/spawner/child2"),
+			WorkerTerminated("root/one/spawner/child1"),
+			WorkerTerminated("root/one/spawner/child0"),
+			SupervisorTerminated("root/one/spawner"),
+			SupervisorTerminated("root/one"),
+			SupervisorTerminated("root"),
+		},
+	)
+}
+
+func TestDynSubtreeFailedTermination(t *testing.T) {
+	subtree := WaitDoneDynSubtree(
+		"one",
+		[]cap.Opt{},
+		[]cap.WorkerOpt{},
+		WaitDoneWorker("child0"),
+		FailTerminationWorker("child1", fmt.Errorf("child1 failed")),
+		WaitDoneWorker("child2"),
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		"root",
+		cap.WithNodes(subtree),
+		[]cap.Opt{},
+		func(EventManager) {},
+	)
+
+	// assert that error contains all information required to assess what went wrong
+	assert.Error(t, err)
+	assert.Equal(t, "supervisor terminated with failures", err.Error())
+
+	t.Run("starts and stops routines in the correct order", func(t *testing.T) {
+		AssertExactMatch(t, events,
+			[]EventP{
+				// The dyn-subtree spawner sub-tree starts always first
+				SupervisorStarted("root/one/spawner"),
+				WorkerStarted("root/one/spawner/child0"),
+				WorkerStarted("root/one/spawner/child1"),
+				WorkerStarted("root/one/spawner/child2"),
+				WorkerStarted("root/one/worker"),
+				SupervisorStarted("root/one"),
+				SupervisorStarted("root"),
+
+				// dyn subtree terminates in reverse order
+				WorkerTerminated("root/one/worker"),
+				WorkerTerminated("root/one/spawner/child2"),
+				WorkerFailedWith("root/one/spawner/child1", "child1 failed"),
+				WorkerTerminated("root/one/spawner/child0"),
+				SupervisorFailed("root/one/spawner"),
+				SupervisorFailed("root/one"),
+				SupervisorFailed("root"),
+			})
+	})
+}
+
+func TestDynSubtreeWorkerStartStopStart(t *testing.T) {
+	subtree := cap.NewDynSubtreeWithNotifyStart(
+		"subtree",
+		func(ctx context.Context, notifyStart cap.NotifyStartFn, spawner cap.Spawner) error {
+			_, _ = spawner.Spawn(WaitDoneWorker("child0"))
+			cancelWorker, err := spawner.Spawn(WaitDoneWorker("child1"))
+			_, _ = spawner.Spawn(WaitDoneWorker("child2"))
+
+			assert.NoError(t, err)
+			err = cancelWorker()
+			assert.NoError(t, err)
+
+			cancelWorker, err = spawner.Spawn(WaitDoneWorker("child1"))
+			assert.NoError(t, err)
+			err = cancelWorker()
+			assert.NoError(t, err)
+
+			// we use notifyStart to make sure there are no race conditions in the
+			// event assertion list bellow
+			notifyStart(nil)
+
+			<-ctx.Done()
+			return nil
+		},
+		[]cap.Opt{},
+	)
+
+	events, err := ObserveSupervisor(
+		context.TODO(),
+		"root",
+		cap.WithNodes(subtree),
+		[]cap.Opt{},
+		func(EventManager) {},
+	)
+	assert.NoError(t, err)
+
+	AssertExactMatch(t, events,
+		[]EventP{
+			// The dyn-subtree spawner sub-tree starts always first
+			SupervisorStarted("root/subtree/spawner"),
+			WorkerStarted("root/subtree/spawner/child0"),
+			WorkerStarted("root/subtree/spawner/child1"),
+			WorkerStarted("root/subtree/spawner/child2"),
+			WorkerTerminated("root/subtree/spawner/child1"),
+			WorkerStarted("root/subtree/spawner/child1"),
+			WorkerTerminated("root/subtree/spawner/child1"),
+
+			WorkerStarted("root/subtree/worker"),
+			SupervisorStarted("root/subtree"),
+			SupervisorStarted("root"),
+
+			// dyn subtree terminates in reverse order
+			WorkerTerminated("root/subtree/worker"),
+			WorkerTerminated("root/subtree/spawner/child2"),
+			// child1 is not here because it was shut down already
+			WorkerTerminated("root/subtree/spawner/child0"),
+			SupervisorTerminated("root/subtree/spawner"),
+			SupervisorTerminated("root/subtree"),
+			SupervisorTerminated("root"),
+		})
+}

--- a/internal/s/monitor.go
+++ b/internal/s/monitor.go
@@ -487,7 +487,7 @@ func runMonitorLoop(
 	supTolerance *restartToleranceManager,
 	supRscCleanup CleanupResourcesFn,
 	supNotifyChan chan c.ChildNotification,
-	ctrlCh chan ctrlMsg,
+	ctrlChan chan ctrlMsg,
 	supStartTime time.Time,
 	onStart c.NotifyStartFn,
 	onTerminate notifyTerminationFn,
@@ -571,7 +571,7 @@ func runMonitorLoop(
 				)
 			}
 
-		case msg := <-ctrlCh:
+		case msg := <-ctrlChan:
 			supChildrenSpecs, supChildren = handleCtrlMsg(
 				supCtx,
 				eventNotifier,

--- a/internal/stest/README.md
+++ b/internal/stest/README.md
@@ -45,7 +45,7 @@ want to make sure an event happens before triggering a new one concurrently.
 
 Finally, this function returns two values, the events that got triggered, and if
 the supervisor failed with an error. You can then use the assertion functions
-(described bellow) to check that the events are the ones you expect.
+(described below) to check that the events are the ones you expect.
 
 ### Assertion functions
 

--- a/internal/stest/assertions.go
+++ b/internal/stest/assertions.go
@@ -130,12 +130,15 @@ func AssertPartialMatch(t *testing.T, evs []cap.Event, preds []EventP) {
 // are testing). This function returns the list of events that happened in the monitored
 // supervised tree, as well as any crash errors.
 func ObserveDynSupervisor(
-	ctx context.Context,
+	ctx0 context.Context,
 	rootName string,
 	childNodes []cap.Node,
 	opts0 []cap.Opt,
 	callback func(cap.DynSupervisor, EventManager),
 ) ([]cap.Event, []error) {
+	ctx, done := context.WithCancel(ctx0)
+	defer done()
+
 	evManager := NewEventManager()
 	// Accumulate the events as they happen
 	evManager.StartCollector(ctx)
@@ -247,13 +250,16 @@ func mergeNotifiers(notifiers []cap.EventNotifier) cap.EventNotifier {
 // are testing). This function returns the list of events that happened in the
 // monitored supervised tree, as well as any crash errors.
 func ObserveSupervisorWithNotifiers(
-	ctx context.Context,
+	ctx0 context.Context,
 	rootName string,
 	buildNodes cap.BuildNodesFn,
 	opts0 []cap.Opt,
 	notifiers []cap.EventNotifier,
 	callback func(EventManager),
 ) ([]cap.Event, error) {
+	ctx, stop := context.WithCancel(ctx0)
+	defer stop()
+
 	evManager := NewEventManager()
 	// Accumulate the events as they happen
 	evManager.StartCollector(ctx)


### PR DESCRIPTION
### Context

As a developer, I want to be able to create `DynamicSupervisor` instances that get managed by a static supervision tree.

### Acceptance Criteria

* [x] A worker and a spawner subtree get created per `NewDynSubtree` call
* [x] Restart strategy for `worker` and `spawner` is `OneForAll`
* [x] Unit tests