### PR TITLE
Bump go version to 1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Introduce `NewDynSubtree` and `NewDynSubtreeWithNotifyStart` to create managed
   subtrees with dynamic worker spawning capabilities. (#66)
 
+* Bump go version to 1.16 (#67)
+
 # v0.1.0 (breaking changes)
 
 * Deprecate `WithTolerance` worker option with `WithRestartTolerance` supervisor

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422 // indirect
 )
 
-go 1.15
+go 1.16


### PR DESCRIPTION
### Context

Prepping up release for capataz-0.2.0 by bumping go version to 1.16