### PR TITLE
move tests to internal/s to better reflect test coverage

### DIFF
--- a/internal/s/capture_panic_test.go
+++ b/internal/s/capture_panic_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 import (
 	"context"

--- a/internal/s/dyn_supervisor_test.go
+++ b/internal/s/dyn_supervisor_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before

--- a/internal/s/healthcheck_test.go
+++ b/internal/s/healthcheck_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 import (
 	"context"

--- a/internal/s/permanent_one_for_all_test.go
+++ b/internal/s/permanent_one_for_all_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before

--- a/internal/s/permanent_one_for_one_test.go
+++ b/internal/s/permanent_one_for_one_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before

--- a/internal/s/supervisor_build_nodes_fn_test.go
+++ b/internal/s/supervisor_build_nodes_fn_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before

--- a/internal/s/supervisor_test.go
+++ b/internal/s/supervisor_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before

--- a/internal/s/temporary_one_for_one_test.go
+++ b/internal/s/temporary_one_for_one_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before

--- a/internal/s/transient_one_for_one_test.go
+++ b/internal/s/transient_one_for_one_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 //
 // NOTE: If you feel it is counter-intuitive to have workers start before

--- a/internal/s/worker_test.go
+++ b/internal/s/worker_test.go
@@ -1,4 +1,4 @@
-package cap_test
+package s_test
 
 import (
 	"context"


### PR DESCRIPTION
### Context

In order to showcase the due diligence in testing of the library, we are moving all tests files to the same package the implementation is, this way, the code coverage tooling will have an accurate report