### PR TITLE
refactor(saboteur): change HTTP server configuration

### DIFF
--- a/saboteur/lib.go
+++ b/saboteur/lib.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/capatazlib/go-capataz/cap"
+	"github.com/sirupsen/logrus"
 )
 
 // planName is a human-readable name provided by API users to identify sabotage
@@ -119,6 +120,7 @@ type sabotageDB struct {
 // Server is a HTTP server that allows us to interact to sabotageDB
 type Server struct {
 	db *sabotageDB
+	ll logrus.FieldLogger
 }
 
 // WorkerGenerator generates worker nodes that trigger errors on demand.

--- a/saboteur/tree.go
+++ b/saboteur/tree.go
@@ -1,17 +1,68 @@
 package saboteur
 
 import (
+	"io/ioutil"
+	"net/http"
+
 	"github.com/capatazlib/go-capataz/cap"
+	"github.com/sirupsen/logrus"
 )
+
+type saboteurSettings struct {
+	ll              logrus.FieldLogger
+	tlsKeyFilepath  string
+	tlsCertFilepath string
+}
+
+// Opt provides ways to customize the SaboteurManager API.
+//
+// @since 0.2.1
+type Opt func(*saboteurSettings)
+
+// WithLogger adds a specific `logrus.FieldLogger` to the logging mechanisms of
+// the saboteur subtree. It defaults to an empty logger otherwise.
+//
+// @since 0.2.1
+func WithLogger(ll logrus.FieldLogger) Opt {
+	return func(opts *saboteurSettings) {
+		opts.ll = ll
+	}
+}
+
+// WithTLS specifies that we want the HTTP server running the saboteur API to
+// use a specific TLS configuration.
+//
+// @since 0.2.1
+func WithTLS(certFilepath, keyFilepath string) Opt {
+	return func(opts *saboteurSettings) {
+		opts.tlsCertFilepath = certFilepath
+		opts.tlsKeyFilepath = keyFilepath
+	}
+}
 
 // NewSaboteurManager creates a subtree that runs workers that trigger sabotage
 // plans in nodes that get created using the WorkerGenerator.
 //
+// HTTP Server Argument
+//
+// The factory function must receive an http.Server value that:
+//
+// * Has an Address attribute intialized.
+//
+// * Does not have a Handler attribute initialized.
+//
+// Users may modify the given http.Server instance in other ways if they so
+// desire.
+//
+// Options
+//
+// This function receives various functions that provide logging or TLS support
+// to the HTTP server.
+//
 // @since 0.2.1
 func NewSaboteurManager(
-	host string,
-	port string,
-	opts ...cap.Opt,
+	httpServer *http.Server,
+	opts ...Opt,
 ) (WorkerGenerator, cap.SupervisorSpec) {
 	// The state is created outside the supervision tree as we rely on the
 	// database to create nodes.
@@ -28,6 +79,20 @@ func NewSaboteurManager(
 		runningPlans:     make(map[planName]stopPlanFn),
 	}
 
+	// Use a logger that discards all output by default.
+	defaultLogger := logrus.New()
+	defaultLogger.SetOutput(ioutil.Discard)
+
+	settings := &saboteurSettings{
+		ll:              defaultLogger,
+		tlsKeyFilepath:  "",
+		tlsCertFilepath: "",
+	}
+
+	for _, optFn := range opts {
+		optFn(settings)
+	}
+
 	spec := cap.NewSupervisorSpec(
 		"saboteur",
 		func() ([]cap.Node, cap.CleanupResourcesFn, error) {
@@ -39,7 +104,16 @@ func NewSaboteurManager(
 				[]cap.Opt{},
 			)
 
-			serverNodes := NewServer(db).Listen(host, port)
+			server := NewServer(settings.ll, db)
+			serverNode, err := server.NewHTTPNode(
+				httpServer,
+				settings.tlsCertFilepath,
+				settings.tlsKeyFilepath,
+			)
+
+			if err != nil {
+				return nil, nil, err
+			}
 
 			cleanupFn := func() error {
 				// Remove all running plan data on a supervisor
@@ -50,9 +124,8 @@ func NewSaboteurManager(
 				return nil
 			}
 
-			return append(serverNodes, dbNode), cleanupFn, nil
+			return []cap.Node{dbNode, serverNode}, cleanupFn, nil
 		},
-		opts...,
 	)
 
 	return db, spec


### PR DESCRIPTION
### Context

This PR introduces a few changes:

* Use an `http.Server` input rather than an `address, port string` input on the subtree creation to allow API consumers to add HTTP middleware as they see fit.

* Make logging an optional functionality

* Make use of logrus.WithError function on log messages

* Add support for TLS on HTTP server