### PR TITLE
add buffers to ReliableNotifier channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.3.0
+
+* Introduce `WithNotifierBufferSize` and `WithEntrypointBufferSize` to `ReliableNotifier`
+* Change `ReliableNofifier` default buffer sizes from 0 to 10
+
 # v0.2.0
 
 * Introduce supervision restart strategy `OneForAll` (#65)

--- a/cap/event_exports.go
+++ b/cap/event_exports.go
@@ -78,6 +78,17 @@ var WithOnNotifierTimeout = n.WithOnNotifierTimeout
 // since: 0.1.0
 var WithNotifierTimeout = n.WithNotifierTimeout
 
+// WithNotifierBufferSize sets the buffer size for each notifier.
+//
+// since: 0.3.0
+var WithNotifierBufferSize = n.WithNotifierBufferSize
+
+// WithEntrypointBufferSize sets the buffer size for entrypoint of the reliable
+// notifier.
+//
+// since: 0.3.0
+var WithEntrypointBufferSize = n.WithEntrypointBufferSize
+
 // WithOnReliableNotifierFailure sets a callback that gets executed when a
 // failure occurs on the event broadcasting logic. You need to ensure the given
 // callback does not block.

--- a/internal/n/reliable_notifier_test.go
+++ b/internal/n/reliable_notifier_test.go
@@ -223,7 +223,9 @@ func TestReliableNotifierSlowNotifier(t *testing.T) {
 	timeoutCallback := func(name string) {
 		assert.Equal(t, "slow", name)
 		current := atomic.LoadInt32(&callbackCounter)
-		if current < expectedCallbackCalls-1 {
+		// buffer size is set to 1, so expect one less timedout callback due to a
+		// notification sitting in the channel buffer
+		if current < expectedCallbackCalls-2 {
 			atomic.AddInt32(&callbackCounter, 1)
 			return
 		}
@@ -242,6 +244,7 @@ func TestReliableNotifierSlowNotifier(t *testing.T) {
 		// use a very small timeout to make the test run fast
 		cap.WithNotifierTimeout(100*time.Microsecond),
 		cap.WithOnNotifierTimeout(timeoutCallback),
+		cap.WithNotifierBufferSize(1),
 	)
 
 	// assert reliable notifier started without errors

--- a/internal/n/reliable_notifier_test.go
+++ b/internal/n/reliable_notifier_test.go
@@ -245,6 +245,7 @@ func TestReliableNotifierSlowNotifier(t *testing.T) {
 		cap.WithNotifierTimeout(100*time.Microsecond),
 		cap.WithOnNotifierTimeout(timeoutCallback),
 		cap.WithNotifierBufferSize(1),
+		cap.WithEntrypointBufferSize(1),
 	)
 
 	// assert reliable notifier started without errors


### PR DESCRIPTION
This is done to avoid the case where a "failed" and "started" noitification
are delivered in quick succession, causing the later notification to be dropped.