### PR TITLE
ci: enable staticcheck

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,11 +1,11 @@
 use_flake() {
     watch_file flake.nix
     watch_file flake.lock
-    watch_file nix/shell.nix
+    watch_file nix/devShell/default/default.nix
+    watch_file nix/pre-commit.nix
     watch_file nix/default.nix
     eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile")"
 }
 
 mkdir -p $(direnv_layout_dir)
 use flake
-figlet "go-Capataz"

--- a/internal/c/options.go
+++ b/internal/c/options.go
@@ -30,7 +30,6 @@ func WithShutdown(s Shutdown) Opt {
 // errors it should be willing to tolerate before giving up restarting it and
 // fail.
 //
-// Deprecated: Use WithRestartTolerance instead.
 func WithTolerance(maxErrCount uint32, errWindow time.Duration) Opt {
 	return func(spec *ChildSpec) {}
 }

--- a/internal/c/types.go
+++ b/internal/c/types.go
@@ -8,7 +8,6 @@ import (
 type Child struct {
 	runtimeName  string
 	spec         ChildSpec
-	restartCount uint32
 	createdAt    time.Time
 	cancel       func()
 	wait         func(Shutdown) (bool, error)

--- a/internal/n/reliable_notifier_test.go
+++ b/internal/n/reliable_notifier_test.go
@@ -110,6 +110,7 @@ func TestReliableNotifierHappyPath(t *testing.T) {
 		},
 		func(EventManager) {},
 	)
+	assert.NoError(t, err)
 
 	// assert the events from the input supervision tree are the expected ones
 	AssertExactMatch(t, events, outEvents)
@@ -191,6 +192,7 @@ func TestReliableNotifierFailureCallback(t *testing.T) {
 		},
 		func(EventManager) {},
 	)
+	assert.NoError(t, err)
 
 	// assert the events from the input supervision tree are the expected ones
 	AssertExactMatch(t, events, outEvents)
@@ -264,6 +266,7 @@ func TestReliableNotifierSlowNotifier(t *testing.T) {
 		},
 		func(EventManager) {},
 	)
+	assert.NoError(t, err)
 
 	// assert the events from the input supervision tree are the expected ones
 	AssertExactMatch(t, events, outEvents)

--- a/internal/s/capture_panic_test.go
+++ b/internal/s/capture_panic_test.go
@@ -41,7 +41,7 @@ func TestCapturePanic(t *testing.T) {
 				SupervisorStarted("root"),
 				// ^^^ supervisor started successfully, from here, it is supervising the
 				// only worker node it has
-				WorkerFailedWith("root/child1", "Panicking child (1 out of 1)"),
+				WorkerFailedWith("root/child1", "panicking child (1 out of 1)"),
 				// ^^^ As specified with the PanicOnSignalWorker, this worker fails
 				// only one time (1 out of 1)
 				WorkerStarted("root/child1"),
@@ -87,7 +87,7 @@ func TestCapturePanic(t *testing.T) {
 				WorkerStarted("root/subtree1/child1"),
 				SupervisorStarted("root/subtree1"),
 				SupervisorStarted("root"),
-				WorkerFailedWith("root/subtree1/child1", "Panicking child (1 out of 1)"),
+				WorkerFailedWith("root/subtree1/child1", "panicking child (1 out of 1)"),
 				WorkerStarted("root/subtree1/child1"),
 				WorkerTerminated("root/subtree1/child1"),
 				SupervisorTerminated("root/subtree1"),

--- a/internal/s/dyn_supervisor.go
+++ b/internal/s/dyn_supervisor.go
@@ -57,7 +57,7 @@ func (scm startChildMsg) processMsg(
 		// but on dynamic supervisors, it means the monitor loop will get bothered
 		// with an error that it should not really handle. We are going to read it
 		// out and return after that.
-		_ = <-supNotifyChan
+		<-supNotifyChan
 		// do not block waiting for a read
 		select {
 		case scm.resultChan <- startChildResult{
@@ -207,7 +207,7 @@ func buildTerminateNodeCallback(ctrlChan chan ctrlMsg, nodeName string) func() e
 		// supervisor is stopped, this line is going to panic
 		select {
 		case ctrlChan <- msg:
-		case _ = <-time.After(1 * time.Second):
+		case <-time.After(1 * time.Second):
 			// This scenario can happen when the supervisor is being terminated and the
 			// non-blocking sup.GetCrashError happened just before that (race
 			// condition).
@@ -236,7 +236,7 @@ func sendSpawnToSupervisor(ctrlChan chan ctrlMsg, node Node) (func() error, erro
 
 	select {
 	case ctrlChan <- msg:
-	case _ = <-time.After(1 * time.Second):
+	case <-time.After(1 * time.Second):
 		// This scenario can happen when the supervisor is being terminated and the
 		// non-blocking sup.GetCrashError happened just before that (race
 		// condition).

--- a/internal/s/dyn_supervisor_test.go
+++ b/internal/s/dyn_supervisor_test.go
@@ -311,6 +311,7 @@ func TestDynCancelWorker(t *testing.T) {
 
 			// spawn a second worker to spice the test a little
 			_, err = sup.Spawn(WaitDoneWorker("two"))
+			assert.NoError(t, err)
 		},
 	)
 
@@ -356,6 +357,7 @@ func TestDynCancelAlreadyTerminatedWorker(t *testing.T) {
 
 			// spawn a second worker to spice the test a little
 			_, err = sup.Spawn(WaitDoneWorker("two"))
+			assert.NoError(t, err)
 		},
 	)
 

--- a/internal/s/error.go
+++ b/internal/s/error.go
@@ -306,7 +306,7 @@ func (err *SupervisorStartError) explainLines() []string {
 	} else {
 		workerErrLines = append(
 			workerErrLines,
-			fmt.Sprintf("supervisor failed to start\n"),
+			"supervisor failed to start\n",
 		)
 		workerErrLines = append(
 			workerErrLines,

--- a/internal/s/permanent_one_for_all_test.go
+++ b/internal/s/permanent_one_for_all_test.go
@@ -573,7 +573,7 @@ func TestPermanentOneForAllSiblingTerminationFailOnRestart(t *testing.T) {
 	explanation := cap.ExplainError(restartEv.Err())
 	assert.Equal(
 		t,
-		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted more than 2 times in a 10s window.\n\tthe original error reported was:\n\t\t> Failing child (1 out of 3)\n\tthe last error reported was:\n\t\t> Failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
+		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted more than 2 times in a 10s window.\n\tthe original error reported was:\n\t\t> failing child (1 out of 3)\n\tthe last error reported was:\n\t\t> failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
 		explanation,
 	)
 

--- a/internal/s/permanent_one_for_one_test.go
+++ b/internal/s/permanent_one_for_one_test.go
@@ -77,7 +77,7 @@ func TestPermanentOneForOneSingleCompleteWorker(t *testing.T) {
 	)
 }
 
-func TestPermanentOneForOneSingleFailingWorkerRecovers(t *testing.T) {
+func TestPermanentOneForOneSinglefailingWorkerRecovers(t *testing.T) {
 	parentName := "root"
 	// Fail only one time
 	child1, failWorker1 := FailOnSignalWorker(1, "child1", cap.WithRestart(cap.Permanent))
@@ -452,7 +452,7 @@ func TestPermanentOneForOneSiblingTerminationFailOnRestart(t *testing.T) {
 	explanation := cap.ExplainError(restartEv.Err())
 	assert.Equal(
 		t,
-		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted more than 2 times in a 10s window.\n\tthe original error reported was:\n\t\t> Failing child (1 out of 3)\n\tthe last error reported was:\n\t\t> Failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
+		"supervisor 'root/subtree1' crashed due to restart tolerance surpassed.\n\tworker node 'root/subtree1/child1' was restarted more than 2 times in a 10s window.\n\tthe original error reported was:\n\t\t> failing child (1 out of 3)\n\tthe last error reported was:\n\t\t> failing child (3 out of 3)\nalso, some siblings failed to terminate while restarting\n\tworker node 'root/subtree1/child2' failed to terminate\n\t\t> child2 termination fail",
 		explanation,
 	)
 

--- a/internal/s/root.go
+++ b/internal/s/root.go
@@ -46,19 +46,6 @@ func withEventNotifier(ctx context.Context, evNotifier EventNotifier) context.Co
 	return context.WithValue(ctx, eventNotifierKey, evNotifier)
 }
 
-// getEventNotifier returns the EventNotifier that is thread-through all the
-// capataz API
-func getEventNotifier(ctx context.Context) (EventNotifier, bool) {
-	val := ctx.Value(eventNotifierKey)
-	if val != nil {
-		if evNotifier, ok := val.(EventNotifier); ok {
-			return evNotifier, true
-		}
-		return nil, false
-	}
-	return nil, false
-}
-
 // rootStart is routine that contains the main logic of a Supervisor. This
 // function:
 //

--- a/internal/s/supervisor.go
+++ b/internal/s/supervisor.go
@@ -106,7 +106,6 @@ type Supervisor struct {
 	terminateCh chan error
 
 	terminateManager        *terminationManager
-	restartToleranceManager *restartToleranceManager
 
 	spec     SupervisorSpec
 	children map[string]c.Child

--- a/internal/s/transient_one_for_one_test.go
+++ b/internal/s/transient_one_for_one_test.go
@@ -224,15 +224,15 @@ func TestTransientOneForOneSingleFailingWorkerReachThreshold(t *testing.T) {
 	assert.Equal(t, "supervisor crashed due to restart tolerance surpassed", err.Error())
 	assert.Equal(t, "root", kvs["supervisor.name"])
 	assert.Equal(t, "root/worker1", kvs["supervisor.restart.node.name"])
-	assert.Equal(t, "Failing child (1 out of 3)", fmt.Sprint(kvs["supervisor.restart.node.error.source.msg"]))
-	assert.Equal(t, "Failing child (3 out of 3)", fmt.Sprint(kvs["supervisor.restart.node.error.last.msg"]))
+	assert.Equal(t, "failing child (1 out of 3)", fmt.Sprint(kvs["supervisor.restart.node.error.source.msg"]))
+	assert.Equal(t, "failing child (3 out of 3)", fmt.Sprint(kvs["supervisor.restart.node.error.last.msg"]))
 	assert.Equal(t, 10*time.Second, kvs["supervisor.restart.node.error.duration"])
 	assert.Equal(t, uint32(2), kvs["supervisor.restart.node.error.count"])
 
 	explanation := cap.ExplainError(err)
 	assert.Equal(
 		t,
-		"supervisor 'root' crashed due to restart tolerance surpassed.\n\tworker node 'root/worker1' was restarted more than 2 times in a 10s window.\n\tthe original error reported was:\n\t\t> Failing child (1 out of 3)\n\tthe last error reported was:\n\t\t> Failing child (3 out of 3)",
+		"supervisor 'root' crashed due to restart tolerance surpassed.\n\tworker node 'root/worker1' was restarted more than 2 times in a 10s window.\n\tthe original error reported was:\n\t\t> failing child (1 out of 3)\n\tthe last error reported was:\n\t\t> failing child (3 out of 3)",
 		explanation,
 	)
 

--- a/internal/s/worker_test.go
+++ b/internal/s/worker_test.go
@@ -11,20 +11,25 @@ import (
 	. "github.com/capatazlib/go-capataz/internal/stest"
 )
 
+type testKey string
+
 func TestWorkerHasContextValuesOnSimpleTree(t *testing.T) {
 	ctx := context.Background()
 
 	valueOne := 123
 	valueTwo := 456
 
-	ctx = context.WithValue(ctx, "value_one", 123)
-	ctx = context.WithValue(ctx, "value_two", 456)
+	valueOneKey := testKey("value_one")
+	valueTwoKey := testKey("value_two")
+
+	ctx = context.WithValue(ctx, valueOneKey, 123)
+	ctx = context.WithValue(ctx, valueTwoKey, 456)
 
 	worker := cap.NewWorker("one", func(ctx context.Context) error {
-		v1 := ctx.Value("value_one").(int)
+		v1 := ctx.Value(valueOneKey).(int)
 		assert.Equal(t, valueOne, v1)
 
-		v2 := ctx.Value("value_two").(int)
+		v2 := ctx.Value(valueTwoKey).(int)
 		assert.Equal(t, valueTwo, v2)
 
 		<-ctx.Done()
@@ -56,14 +61,17 @@ func TestWorkerHasContextValuesOnNestedTree(t *testing.T) {
 	valueOne := 123
 	valueTwo := 456
 
-	ctx = context.WithValue(ctx, "value_one", 123)
-	ctx = context.WithValue(ctx, "value_two", 456)
+	valueOneKey := testKey("value_one")
+	valueTwoKey := testKey("value_two")
+
+	ctx = context.WithValue(ctx, valueOneKey, 123)
+	ctx = context.WithValue(ctx, valueTwoKey, 456)
 
 	worker := cap.NewWorker("one", func(ctx context.Context) error {
-		v1 := ctx.Value("value_one").(int)
+		v1 := ctx.Value(valueOneKey).(int)
 		assert.Equal(t, valueOne, v1)
 
-		v2 := ctx.Value("value_two").(int)
+		v2 := ctx.Value(valueTwoKey).(int)
 		assert.Equal(t, valueTwo, v2)
 
 		<-ctx.Done()

--- a/internal/stest/assertions.go
+++ b/internal/stest/assertions.go
@@ -22,7 +22,7 @@ func renderEvents(evs []cap.Event) string {
 func verifyExactMatch(preds []EventP, given []cap.Event) error {
 	if len(preds) != len(given) {
 		return fmt.Errorf(
-			"Expecting exact match, but length is not the same:\nwant: %d\ngiven: %d\nevents:\n%s",
+			"expecting exact match, but length is not the same:\nwant: %d\ngiven: %d\nevents:\n%s",
 			len(preds),
 			len(given),
 			renderEvents(given),
@@ -31,7 +31,7 @@ func verifyExactMatch(preds []EventP, given []cap.Event) error {
 	for i, pred := range preds {
 		if !pred.Call(given[i]) {
 			return fmt.Errorf(
-				"Expecting exact match, but entry %d did not match:\ncriteria: %s\nevent: %s\nevents:\n%s",
+				"expecting exact match, but entry %d did not match:\ncriteria: %s\nevent: %s\nevents:\n%s",
 				i,
 				pred.String(),
 				given[i].String(),

--- a/internal/stest/workers.go
+++ b/internal/stest/workers.go
@@ -77,7 +77,7 @@ func FailOnSignalDynSubtree(
 			if currentFailCount < totalErrCount {
 				atomic.AddInt32(&currentFailCount, 1)
 				return fmt.Errorf(
-					"Failing dyn subtree worker (%d out of %d)", currentFailCount, totalErrCount,
+					"failing dyn subtree worker (%d out of %d)", currentFailCount, totalErrCount,
 				)
 			}
 
@@ -170,7 +170,7 @@ func FailOnSignalWorker(
 			}
 			if currentFailCount < totalErrCount {
 				atomic.AddInt32(&currentFailCount, 1)
-				return fmt.Errorf("Failing child (%d out of %d)", currentFailCount, totalErrCount)
+				return fmt.Errorf("failing child (%d out of %d)", currentFailCount, totalErrCount)
 			}
 			<-ctx.Done()
 			return nil
@@ -204,7 +204,7 @@ func PanicOnSignalWorker(
 			<-startCh
 			if currentFailCount < totalErrCount {
 				atomic.AddInt32(&currentFailCount, 1)
-				err := fmt.Errorf("Panicking child (%d out of %d)", currentFailCount, totalErrCount)
+				err := fmt.Errorf("panicking child (%d out of %d)", currentFailCount, totalErrCount)
 				panic(err)
 			}
 			<-ctx.Done()

--- a/nix/pre-commit.nix
+++ b/nix/pre-commit.nix
@@ -94,7 +94,7 @@ system: {self, ...}: {
     };
 
     staticcheck = {
-      enable = false;
+      enable = true;
       name = "staticheck";
       description = "State of the art linter for the Go programming language";
       # staticheck works with directories.


### PR DESCRIPTION
### Context

The staticcheck tool helps learn common mistakes in golang code. This PR also fixes all warnings registered so far.