### PR TITLE
propagate panic in worker start as a start err

### DIFF
--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -153,6 +153,9 @@ func (chSpec ChildSpec) DoStart(
 				if !ok {
 					panicErr = fmt.Errorf("panic error: %v", panicVal)
 				}
+
+				startCh <- panicErr
+
 				sendNotificationToSup(
 					panicErr,
 					chSpec,
@@ -167,11 +170,9 @@ func (chSpec ChildSpec) DoStart(
 		// block and wait here until an error (or lack of) is reported from the
 		// client code
 		err := chSpec.Start(childCtx, func(err error) {
-			// we tell the spawner this child thread has started running
-			if err != nil {
-				startCh <- err
-			}
-			close(startCh)
+			// we tell the spawner this child thread has started running. err may be
+			// nil
+			startCh <- err
 		})
 
 		sendNotificationToSup(

--- a/internal/stest/workers.go
+++ b/internal/stest/workers.go
@@ -120,6 +120,24 @@ func FailStartWorker(name string) cap.Node {
 	return cspec
 }
 
+// PanicStartWorker creates a `cap.Node` that runs a goroutine that panics on
+// start
+func PanicStartWorker(name string) cap.Node {
+	cspec := cap.NewWorkerWithNotifyStart(
+		name,
+		func(ctx context.Context, notifyStart cap.NotifyStartFn) error {
+			err := fmt.Errorf("PanicStartWorker %s", name)
+			panic(err)
+			// NOTE: Even though we return the err value here, this err will never be
+			// caught by our supervisor restart logic. If we invoke notifyStart with a
+			// non-nil err, the supervisor will never get to the supervision loop, but
+			// instead is going to terminate all started children and abort the
+			// bootstrap of the supervision tree.
+			return err
+		})
+	return cspec
+}
+
 // NeverTerminateWorker creates a `cap.Node` that runs a goroutine that never stops
 // when asked to, causing the goroutine to leak in the runtime
 func NeverTerminateWorker(name string) cap.Node {


### PR DESCRIPTION
Fixes #86

Treat a panic that occurs during `NewWorkerWithNotifyStart` the same as calling notify start with an error.