### PR TITLE
ensure close is only called once

### DIFF
--- a/internal/n/reliable_notifier_test.go
+++ b/internal/n/reliable_notifier_test.go
@@ -18,14 +18,11 @@ import (
 // will block until the given number of notifications have happened
 func newBlockingNotifier(total int32) (cap.EventNotifier, func()) {
 	doneCh := make(chan struct{})
-	evCount := int32(0)
+	evCount := &atomic.Int32{}
 	evNotifier := func(cap.Event) {
-		current := atomic.LoadInt32(&evCount)
-		if current < total-1 {
-			atomic.AddInt32(&evCount, 1)
-			return
+		if evCount.Add(1) == total {
+			close(doneCh)
 		}
-		close(doneCh)
 	}
 	doneSignal := func() {
 		<-doneCh
@@ -37,14 +34,13 @@ func newBlockingNotifier(total int32) (cap.EventNotifier, func()) {
 // that will block until the given number of panic calls have happened
 func newPanicBlockingNotifier(total int32) (cap.EventNotifier, func()) {
 	doneCh := make(chan struct{})
-	evCount := int32(0)
+	evCount := &atomic.Int32{}
 	evNotifier := func(ev cap.Event) {
-		current := atomic.LoadInt32(&evCount)
-		if current < total-1 {
-			atomic.AddInt32(&evCount, 1)
+		if evCount.Add(1) == total {
+			close(doneCh)
+		} else {
 			panic("this is taking down the tree")
 		}
-		close(doneCh)
 	}
 	doneSignal := func() {
 		<-doneCh
@@ -152,9 +148,9 @@ func TestReliableNotifierFailureCallback(t *testing.T) {
 
 	// build a callback function for event notifier errors
 	callbackDone := make(chan struct{})
-	errCount := int32(0)
+	errCount := &atomic.Int32{}
 	errCallback := func(err error) {
-		if atomic.AddInt32(&errCount, 1) == expectedCallbackCalls {
+		if errCount.Add(1) == expectedCallbackCalls {
 			close(callbackDone)
 		}
 	}
@@ -218,17 +214,14 @@ func TestReliableNotifierSlowNotifier(t *testing.T) {
 	callbacksDone := make(chan struct{})
 	// all events but the first one should timeout
 	expectedCallbackCalls := int32(len(outEvents) - 1)
-	callbackCounter := int32(0)
+	callbackCounter := &atomic.Int32{}
 	timeoutCallback := func(name string) {
 		assert.Equal(t, "slow", name)
-		current := atomic.LoadInt32(&callbackCounter)
 		// buffer size is set to 1, so expect one less timedout callback due to a
 		// notification sitting in the channel buffer
-		if current < expectedCallbackCalls-2 {
-			atomic.AddInt32(&callbackCounter, 1)
-			return
+		if callbackCounter.Add(1) == expectedCallbackCalls-1 {
+			close(callbacksDone)
 		}
-		close(callbacksDone)
 	}
 
 	notifier1, done1 := newBlockingNotifier(int32(len(outEvents)))

--- a/internal/n/reliable_notifier_test.go
+++ b/internal/n/reliable_notifier_test.go
@@ -154,12 +154,9 @@ func TestReliableNotifierFailureCallback(t *testing.T) {
 	callbackDone := make(chan struct{})
 	errCount := int32(0)
 	errCallback := func(err error) {
-		current := atomic.LoadInt32(&errCount)
-		if current < expectedCallbackCalls-1 {
-			atomic.AddInt32(&errCount, 1)
-			return
+		if atomic.AddInt32(&errCount, 1) == expectedCallbackCalls {
+			close(callbackDone)
 		}
-		close(callbackDone)
 	}
 
 	// create the reliable event notifier that broadcasts to notifiers created in


### PR DESCRIPTION
```
panic: close of closed channel

goroutine 48 [running]:
github.com/capatazlib/go-capataz/internal/n_test.TestReliableNotifierFailureCallback.func1({0x0?, 0x4a6405?})
	/home/runner/work/go-capataz/go-capataz/internal/n/reliable_notifier_test.go:162 +0x79
github.com/capatazlib/go-capataz/internal/n.notifyRootFailure.func1({0x4, 0x1, {0xc000020880, 0x1b}, {0x7778a0, 0xc0001a7800}, {0xc146304f509577f5, 0x7463f1, 0x8e3b40}, 0x0})
	/home/runner/work/go-capataz/go-capataz/internal/n/reliable_notifier.go:158 +0x1cb
github.com/capatazlib/go-capataz/internal/s.EventNotifier.processFailed(0xc0001b4640, 0x1, {0xc000020880, 0x1b}, {0x7778a0, 0xc0001a7800})
	/home/runner/work/go-capataz/go-capataz/internal/s/event.go:[146](https://github.com/capatazlib/go-capataz/actions/runs/6633387155/job/18021009008#step:5:147) +0x122
github.com/capatazlib/go-capataz/internal/s.terminateChildNode(0x1?, {{0xc000020880, 0x1b}, {{0x706c14, 0x9}, 0x1, {0x0, 0x0}, 0x0, 0x1, ...}, ...})
	/home/runner/work/go-capataz/go-capataz/internal/s/monitor.go:351 +0x1bb
github.com/capatazlib/go-capataz/internal/s.terminateChildNodes({{0x709457, 0x11}, {0x64, 0x3b9aca00}, 0xc00006e740, 0x0, 0x0, 0x12a05f200, 0xc0001b4640}, {0xc0001a4310, ...}, ...)
	/home/runner/work/go-capataz/go-capataz/internal/s/monitor.go:389 +0x3c5
github.com/capatazlib/go-capataz/internal/s.terminateSupervisor({{0x709457, 0x11}, {0x64, 0x3b9aca00}, 0xc00006e740, 0x0, 0x0, 0x12a05f200, 0xc0001b4640}, {0xc0001a4310, ...}, ...)
	/home/runner/work/go-capataz/go-capataz/internal/s/monitor.go:413 +0x156
github.com/capatazlib/go-capataz/internal/s.runMonitorLoop({0x778ce0, 0xc0001a6e70}, {{0x709457, 0x11}, {0x64, 0x3b9aca00}, 0xc00006e740, 0x0, 0x0, 0x12a05f200, ...}, ...)
	/home/runner/work/go-capataz/go-capataz/internal/s/monitor.go:528 +0x936
github.com/capatazlib/go-capataz/internal/s.SupervisorSpec.rootStart.func4()
	/home/runner/work/go-capataz/go-capataz/internal/s/root.go:161 +0x1ec
created by github.com/capatazlib/go-capataz/internal/s.SupervisorSpec.rootStart
	/home/runner/work/go-capataz/go-capataz/internal/s/root.go:[157](https://github.com/capatazlib/go-capataz/actions/runs/6633387155/job/18021009008#step:5:158) +0xc4b
FAIL	github.com/capatazlib/go-capataz/internal/n	0.024s
FAIL
```