### PR TITLE
Include stack trace in panic error messages

### DIFF
--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"time"
 )
@@ -156,7 +157,7 @@ func (chSpec ChildSpec) DoStart(
 
 				panicErr, ok := panicVal.(error)
 				if !ok {
-					panicErr = fmt.Errorf("panic error: %v", panicVal)
+					panicErr = fmt.Errorf("panic error: %v\n%s", panicVal, debug.Stack())
 				}
 
 				select {

--- a/internal/s/dyn_supervisor.go
+++ b/internal/s/dyn_supervisor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/capatazlib/go-capataz/internal/c"
@@ -196,7 +197,7 @@ func buildTerminateNodeCallback(ctrlChan chan ctrlMsg, nodeName string) func() e
 			}
 
 			if panicErr, ok := panicVal.(error); ok {
-				err = fmt.Errorf("could not talk to supervisor: %w", panicErr)
+				err = fmt.Errorf("could not talk to supervisor: %w\n%s", panicErr, debug.Stack())
 				return
 			}
 

--- a/internal/s/dyn_supervisor_test.go
+++ b/internal/s/dyn_supervisor_test.go
@@ -389,5 +389,5 @@ func TestDynCancelAlreadyTerminatedSupervisor(t *testing.T) {
 
 	err = cancelWorker()
 	assert.Error(t, err)
-	assert.Equal(t, "could not talk to supervisor: send on closed channel", err.Error())
+	assert.Contains(t, err.Error(), "could not talk to supervisor: send on closed channel")
 }

--- a/internal/s/spec.go
+++ b/internal/s/spec.go
@@ -3,6 +3,7 @@ package s
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/capatazlib/go-capataz/internal/c"
@@ -121,7 +122,7 @@ func reliableBuildNodes(
 		if panicVal != nil {
 			err = &SupervisorBuildError{
 				supRuntimeName: supRuntimeName,
-				buildNodesErr:  fmt.Errorf("%v", panicVal),
+				buildNodesErr:  fmt.Errorf("%v\n%s", panicVal, debug.Stack()),
 			}
 		}
 	}()

--- a/internal/s/supervisor_build_nodes_fn_test.go
+++ b/internal/s/supervisor_build_nodes_fn_test.go
@@ -91,13 +91,13 @@ func TestSupervisorWithPanicBuildNodesFnOnSingleTree(t *testing.T) {
 	kvs := errKVs.KVs()
 	assert.Equal(t, "supervisor build nodes function failed", err.Error())
 	assert.Equal(t, "root", kvs["supervisor.name"])
-	assert.Equal(t, "single tree panic", fmt.Sprint(kvs["supervisor.build.error"]))
+	assert.Contains(t, fmt.Sprint(kvs["supervisor.build.error"]), "single tree panic")
 
 	explanation := cap.ExplainError(err)
-	assert.Equal(
+	assert.Contains(
 		t,
-		"supervisor 'root' build nodes function failed\n\t> single tree panic",
 		explanation,
+		"supervisor 'root' build nodes function failed\n\t> single tree panic",
 	)
 
 	AssertExactMatch(t, events,
@@ -134,13 +134,13 @@ func TestSupervisorWithPanicBuildNodesFnOnNestedTree(t *testing.T) {
 	kvs := errKVs.KVs()
 	assert.Equal(t, "supervisor node failed to start", err.Error())
 	assert.Equal(t, "root/subtree2", kvs["supervisor.subtree.name"])
-	assert.Equal(t, "sub-tree panic", fmt.Sprint(kvs["supervisor.subtree.build.error"]))
+	assert.Contains(t, fmt.Sprint(kvs["supervisor.subtree.build.error"]), "sub-tree panic")
 
 	explanation := cap.ExplainError(err)
-	assert.Equal(
+	assert.Contains(
 		t,
-		"supervisor 'root/subtree2' build nodes function failed\n\t> sub-tree panic",
 		explanation,
+		"supervisor 'root/subtree2' build nodes function failed\n\t> sub-tree panic",
 	)
 
 	AssertExactMatch(t, events,


### PR DESCRIPTION
This will aid in debugging issues caused by panics by including where they originate in the error message.