### PR TITLE
include richer panic data as KVs

### DIFF
--- a/internal/c/error.go
+++ b/internal/c/error.go
@@ -1,0 +1,66 @@
+package c
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+)
+
+type errorWithKVs struct {
+	error
+	kvs map[string]interface{}
+}
+
+type kvser interface {
+	KVs() map[string]interface{}
+}
+
+func (err *errorWithKVs) KVs() map[string]interface{} {
+	if inner, ok := err.error.(kvser); ok {
+		kvs := make(map[string]interface{})
+		for k, v := range inner.KVs() {
+			kvs[k] = v
+		}
+		for k, v := range err.kvs {
+			kvs[k] = v
+		}
+		return kvs
+	}
+
+	return err.kvs
+}
+
+func (err *errorWithKVs) GetKVs() map[string]interface{} {
+	return err.KVs()
+}
+
+func (err *errorWithKVs) Unwrap() error {
+	return err.error
+}
+
+func withPanicLocation(err error) error {
+	return &errorWithKVs{
+		error: err,
+		kvs: map[string]interface{}{
+			"panic.location": panicLocation(1),
+			"stacktrace":     string(debug.Stack()),
+		},
+	}
+}
+
+// panicLocation will, when called from within a `defer` when `recover() !=
+// nil`, will return the location of the panic. If called from another function,
+// increment `skip` to account for extra stack frames.
+func panicLocation(skip int) string {
+	pc, file, line, ok := runtime.Caller(skip + 3)
+	if !ok {
+		return "unknown"
+	}
+
+	fc := runtime.FuncForPC(pc)
+	if fc == nil {
+		return "unknown"
+	}
+
+	return fmt.Sprintf("%s:%d %s", file, line, fc.Name())
+}

--- a/internal/c/error_test.go
+++ b/internal/c/error_test.go
@@ -1,0 +1,41 @@
+package c
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func boomErr() (ret error) {
+	defer func() {
+		p := recover()
+		err := fmt.Errorf("%v", p)
+		ret = withPanicLocation(err)
+	}()
+	panic("boom!")
+}
+
+func boomStr() (ret string) {
+	defer func() {
+		_ = recover()
+		ret = panicLocation(0)
+	}()
+	panic("boom!")
+}
+
+func TestPanicLocation(t *testing.T) {
+	require := require.New(t)
+	str := boomStr()
+	require.Contains(str, "c/error_test.go:24")
+
+	err := boomErr()
+	require.Equal("boom!", err.Error())
+	kvs := err.(interface{ KVs() map[string]interface{} }).KVs()
+	require.Contains(kvs["panic.location"], "c/error_test.go:16")
+	require.Contains(kvs["panic.location"], "internal/c.boom")
+	require.NotContains(kvs["panic.location"], "\n")
+	require.Contains(kvs["stacktrace"], "c/error_test.go:16")
+	require.Contains(kvs["stacktrace"], "internal/c.boomErr")
+	require.Contains(kvs["stacktrace"], "\n")
+}

--- a/internal/c/start.go
+++ b/internal/c/start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime/debug"
 	"strings"
 	"time"
 )
@@ -157,8 +156,9 @@ func (chSpec ChildSpec) DoStart(
 
 				panicErr, ok := panicVal.(error)
 				if !ok {
-					panicErr = fmt.Errorf("panic error: %v\n%s", panicVal, debug.Stack())
+					panicErr = fmt.Errorf("%v", panicVal)
 				}
+				panicErr = withPanicLocation(panicErr)
 
 				select {
 				case startCh <- panicErr:

--- a/internal/s/supervisor_test.go
+++ b/internal/s/supervisor_test.go
@@ -273,6 +273,8 @@ func TestStartPanicChild(t *testing.T) {
 	kvs := errKVs.KVs()
 	assert.Equal(t, "supervisor node failed to start", err.Error())
 	assert.Equal(t, "root", kvs["supervisor.name"])
+	assert.Contains(t, kvs["panic.location"], "internal/stest/workers.go:130")
+	assert.Contains(t, kvs["stacktrace"], "internal/stest/workers.go:130")
 	assert.Equal(t, "root/branch1", kvs["supervisor.subtree.name"])
 	assert.Equal(t,
 		"PanicStartWorker child3",


### PR DESCRIPTION
Use error KVs to include two new values: full stacktrace and the exact location of the panic. Always include these values on panics regardless of the panic type.